### PR TITLE
feat(#165): add support for updating the Sentinel backlog

### DIFF
--- a/dist/commands/sentinel-backlog/index.js
+++ b/dist/commands/sentinel-backlog/index.js
@@ -1,0 +1,6 @@
+import { Command } from '@effect/cli';
+import { ls } from "./ls.js";
+import { setSequence } from './set-sequence.js';
+export const sentinelBacklog = Command
+    .make('sentinel-backlog', {})
+    .pipe(Command.withDescription(`Manage Sentinel backlog.`), Command.withSubcommands([ls, setSequence]));

--- a/dist/commands/sentinel-backlog/ls.js
+++ b/dist/commands/sentinel-backlog/ls.js
@@ -1,0 +1,17 @@
+import { Command } from '@effect/cli';
+import { Console, Effect, Number, Option, pipe, String, Tuple } from 'effect';
+import { initializeUrl } from "../../index.js";
+import { SentinelBacklogService } from '../../services/sentinel-backlog.js';
+import { color } from '../../libs/console.js';
+const getBacklog = (sequenceData) => pipe(sequenceData, Tuple.map(String.split('-')), Tuple.map(Tuple.at(0)), Tuple.map(Number.parse), Tuple.map(Option.getOrElse(() => NaN)), ([transSeq, updateSeq]) => updateSeq - transSeq, backlog => backlog.toString());
+const logInfo = (sequenceData) => pipe(sequenceData, Tuple.map(color('green')), ([transSeq, updateSeq]) => Console.log(`
+Sentinel Backlog: ${pipe(getBacklog(sequenceData), color('blue'))}
+Transitions seq: ${transSeq}
+Medic update seq: ${updateSeq}
+  `));
+export const ls = Command
+    .make('ls', {}, () => initializeUrl.pipe(Effect.andThen(Effect.all([
+    SentinelBacklogService.getTransitionsSeq(),
+    SentinelBacklogService.getMedicUpdateSeq()
+], { concurrency: 'unbounded' })), Effect.flatMap(logInfo)))
+    .pipe(Command.withDescription(`List current Sentinel backlog details.`));

--- a/dist/commands/sentinel-backlog/set-sequence.js
+++ b/dist/commands/sentinel-backlog/set-sequence.js
@@ -1,0 +1,37 @@
+import { Args, Command, Options, Prompt } from '@effect/cli';
+import { Boolean, Console, Effect, Option, pipe } from 'effect';
+import { color } from "../../libs/console.js";
+import { initializeUrl } from '../../index.js';
+import { SentinelBacklogService } from '../../services/sentinel-backlog.js';
+const validateParams = Effect.fn((value, latest) => pipe(value, Option.isSome, Boolean.xor(latest), Effect.succeed, Effect.filterOrFail(valid => valid, () => new Error('Must provide either the --latest flag or a value argument (but not both).'))));
+const getNewSequenceValue = Effect.fn((value) => pipe(value, Option.map(Effect.succeed), Option.getOrElse(() => SentinelBacklogService.getMedicUpdateSeq())));
+const getConfirmationPrompt = (currentTransitionSeq, newTransitionSeq) => Prompt.confirm({
+    message: `You are about to update the Sentinel transition sequence:
+  
+Current value: ${pipe(currentTransitionSeq, color('green'))}
+New value: ${pipe(newTransitionSeq, color('green'))}  
+
+Are you sure you want to make this update?`,
+    initial: false,
+});
+const isRemoveConfirmed = Effect.fn((yes, currentTransitionSeq, newTransitionSeq) => Effect
+    .succeed(true)
+    .pipe(Effect.filterOrElse(() => yes, () => getConfirmationPrompt(currentTransitionSeq, newTransitionSeq))));
+const value = Args
+    .text({ name: 'value' })
+    .pipe(Args.withDescription('The sequence value to set. This is the target update-seq value from the medic database. '
+    + 'Required when --latest is not set.'), Args.optional);
+const latest = Options
+    .boolean('latest')
+    .pipe(Options.withDescription('Set the Sentinel transitions sequence value to the current update-seq value from the medic database. '
+    + 'Cannot be used when providing a value argument.'));
+const yes = Options
+    .boolean('yes')
+    .pipe(Options.withAlias('y'), Options.withDescription('Do not prompt for confirmation.'));
+export const setSequence = Command
+    .make('set-sequence', { value, latest, yes }, ({ value, latest, yes }) => initializeUrl.pipe(Effect.andThen(validateParams(value, latest)), Effect.andThen(Effect.all([
+    SentinelBacklogService.getTransitionsSeq(),
+    getNewSequenceValue(value)
+], { concurrency: 'unbounded' })), Effect.flatMap(([currentSeq, newSeq]) => pipe(isRemoveConfirmed(yes, currentSeq, newSeq), Effect.map(removeConfirmed => Option.liftPredicate(SentinelBacklogService.setTransitionsSeq(newSeq), () => removeConfirmed)), Effect.flatMap(Option.getOrElse(() => Console.log('Operation cancelled')))))))
+    .pipe(Command.withDescription('Update the Sentinel transitions sequence value. The Sentinel container should be stopped before '
+    + 'performing this operation and then started again once the update is complete.'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -25,6 +25,8 @@ import { instance } from "./commands/instance/index.js";
 import { LocalInstanceService } from "./services/local-instance.js";
 import { localIp } from "./commands/local-ip/index.js";
 import { LocalIpService } from "./services/local-ip.js";
+import { SentinelBacklogService } from './services/sentinel-backlog.js';
+import { sentinelBacklog } from './commands/sentinel-backlog/index.js';
 const url = Options
     .text('url')
     .pipe(Options.withDescription('The URL of the CouchDB server. Defaults to the COUCH_URL environment variable. Note that since this tool is ' +
@@ -34,7 +36,7 @@ const setEnv = (url) => Effect.flatMap(EnvironmentService, envSvc => envSvc.setU
 const getEnv = Effect.flatMap(EnvironmentService, envSvc => envSvc.get());
 export const initializeUrl = chtx.pipe(Effect.map(({ url }) => url), Effect.map(Option.map(Redacted.make)), Effect.map(Option.map(setEnv)), Effect.flatMap(Option.getOrElse(() => getEnv)), Effect.map(({ url }) => Redacted.value(url)), Effect.map(Option.liftPredicate(String.isNonEmpty)), Effect.map(Option.getOrThrowWith(() => new Error('A value must be set for the COUCH_URL envar or the --url option.'))));
 const command = chtx.pipe(Command.withSubcommands([
-    design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance
+    design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance, sentinelBacklog
 ]));
 const cli = Command.run(command, {
     name: 'CHT Toolbox',
@@ -42,4 +44,4 @@ const cli = Command.run(command, {
 });
 const httpClientNoSslVerify = Layer.provide(NodeHttpClient.layerWithoutAgent.pipe(Layer.provide(NodeHttpClient.makeAgentLayer({ rejectUnauthorized: false }))));
 cli(process.argv)
-    .pipe(Effect.provide(CompactService.Default), Effect.provide(MonitorService.Default), Effect.provide(LocalDiskUsageService.Default), Effect.provide(LocalInstanceService.Default.pipe(httpClientNoSslVerify)), Effect.provide(LocalIpService.Default), Effect.provide(PurgeService.Default), Effect.provide(UpgradeService.Default), Effect.provide(WarmViewsService.Default), Effect.provide(ReplicateService.Default), Effect.provide(TestDataGeneratorService.Default), Effect.provide(PouchDBService.Default), Effect.provide(ChtClientService.Default.pipe(httpClientNoSslVerify)), Effect.provide(EnvironmentService.Default), Effect.provide(NodeContext.layer), NodeRuntime.runMain);
+    .pipe(Effect.provide(CompactService.Default), Effect.provide(MonitorService.Default), Effect.provide(LocalDiskUsageService.Default), Effect.provide(LocalInstanceService.Default.pipe(httpClientNoSslVerify)), Effect.provide(LocalIpService.Default), Effect.provide(PurgeService.Default), Effect.provide(UpgradeService.Default), Effect.provide(WarmViewsService.Default), Effect.provide(ReplicateService.Default), Effect.provide(SentinelBacklogService.Default), Effect.provide(TestDataGeneratorService.Default), Effect.provide(PouchDBService.Default), Effect.provide(ChtClientService.Default.pipe(httpClientNoSslVerify)), Effect.provide(EnvironmentService.Default), Effect.provide(NodeContext.layer), NodeRuntime.runMain);

--- a/dist/libs/console.js
+++ b/dist/libs/console.js
@@ -1,12 +1,11 @@
 import { Console, Effect, FiberRef, LogLevel, pipe } from 'effect';
-// const ANSI_CODES = {
-//   red: '\x1b[31m',
-//   green: '\x1b[32m',
-//   blue: '\x1b[34m'
-// };
-// type AnsiColor = keyof typeof ANSI_CODES;
-// const resetCode = '\x1b[0m';
-// export const color = (color: AnsiColor) => (text: string): string => `${ANSI_CODES[color]}${text}${resetCode}`;
+const ANSI_CODES = {
+    red: '\x1b[31m',
+    green: '\x1b[32m',
+    blue: '\x1b[34m'
+};
+const resetCode = '\x1b[0m';
+export const color = (color) => (text) => `${ANSI_CODES[color]}${text}${resetCode}`;
 export const debugLoggingEnabled = FiberRef
     .get(FiberRef.currentMinimumLogLevel)
     .pipe(Effect.map(LogLevel.lessThanEqual(LogLevel.Debug)));

--- a/dist/services/sentinel-backlog.js
+++ b/dist/services/sentinel-backlog.js
@@ -1,0 +1,30 @@
+import * as Effect from 'effect/Effect';
+import * as Context from 'effect/Context';
+import { getDoc, PouchDBService, saveDoc } from "./pouchdb.js";
+import { Array, Option, pipe, Record, Schema } from 'effect';
+import { ChtClientService } from "./cht-client.js";
+import { getDbsInfoByName } from "../libs/couch/dbs-info.js";
+class LocalTransitionsSeq extends Schema.Class('LocalTransitionsSeq')({
+    value: Schema.String,
+}) {
+}
+const medicUpdateSeqEffect = Effect.suspend(() => pipe(getDbsInfoByName(['medic']), Effect.map(Array.unsafeGet(0)), Effect.map(({ info }) => info.update_seq), Effect.tap(updateSeq => Effect.logDebug(`medic update_seq: ${updateSeq}`))));
+const localTransitionsSeqEffect = Effect.suspend(() => pipe('_local/transitions-seq', getDoc('medic-sentinel'), Effect.map(Option.flatMap(Schema.decodeUnknownOption(LocalTransitionsSeq, { onExcessProperty: 'preserve' }))), Effect.map(Option.getOrThrowWith(() => new Error('No _local/transitions-seq doc found.'))), Effect.tap(seq => Effect.logDebug(`local transitions seq: ${seq.value}`))));
+const setLocalTransitionsSeq = Effect.fn((value) => pipe(localTransitionsSeqEffect, Effect.map(Record.set('value', value)), Effect.flatMap(saveDoc('medic-sentinel')), Effect.tap(() => Effect.logDebug(`Local transitions seq updated to ${value}`))));
+const serviceContext = Effect
+    .all([
+    ChtClientService,
+    PouchDBService,
+])
+    .pipe(Effect.map(([chtClient, pouch,]) => Context
+    .make(PouchDBService, pouch)
+    .pipe(Context.add(ChtClientService, chtClient))));
+export class SentinelBacklogService extends Effect.Service()('chtoolbox/SentinelBacklogService', {
+    effect: serviceContext.pipe(Effect.map(context => ({
+        getMedicUpdateSeq: () => pipe(medicUpdateSeqEffect, Effect.provide(context)),
+        getTransitionsSeq: () => pipe(localTransitionsSeqEffect, Effect.map(({ value }) => value), Effect.provide(context)),
+        setTransitionsSeq: (value) => pipe(setLocalTransitionsSeq(value), Effect.mapError(x => x), Effect.asVoid, Effect.provide(context)),
+    }))),
+    accessors: true,
+}) {
+}

--- a/src/commands/sentinel-backlog/index.ts
+++ b/src/commands/sentinel-backlog/index.ts
@@ -1,0 +1,10 @@
+import { Command } from '@effect/cli';
+import { ls } from './ls.ts';
+import { setSequence } from './set-sequence.js';
+
+export const sentinelBacklog = Command
+  .make('sentinel-backlog', {})
+  .pipe(
+    Command.withDescription(`Manage Sentinel backlog.`),
+    Command.withSubcommands([ls, setSequence])
+  );

--- a/src/commands/sentinel-backlog/ls.ts
+++ b/src/commands/sentinel-backlog/ls.ts
@@ -1,0 +1,35 @@
+import { Command } from '@effect/cli';
+import { Console, Effect, Number, Option, pipe, String, Tuple } from 'effect';
+import { initializeUrl } from '../../index.ts';
+import { SentinelBacklogService } from '../../services/sentinel-backlog.js';
+import { color } from '../../libs/console.js';
+
+const getBacklog = (sequenceData: [string, string]) => pipe(
+  sequenceData,
+  Tuple.map(String.split('-')),
+  Tuple.map(Tuple.at(0)),
+  Tuple.map(Number.parse),
+  Tuple.map(Option.getOrElse(() => NaN)),
+  ([transSeq, updateSeq]) => updateSeq - transSeq,
+  backlog => backlog.toString()
+);
+
+const logInfo = (sequenceData: [string, string]) => pipe(
+  sequenceData,
+  Tuple.map(color('green')),
+  ([transSeq, updateSeq]) => Console.log(`
+Sentinel Backlog: ${pipe(getBacklog(sequenceData), color('blue'))}
+Transitions seq: ${transSeq}
+Medic update seq: ${updateSeq}
+  `),
+);
+
+export const ls = Command
+  .make('ls', {}, () => initializeUrl.pipe(
+    Effect.andThen(Effect.all([
+      SentinelBacklogService.getTransitionsSeq(),
+      SentinelBacklogService.getMedicUpdateSeq()
+    ], { concurrency: 'unbounded' })),
+    Effect.flatMap(logInfo),
+  ))
+  .pipe(Command.withDescription(`List current Sentinel backlog details.`));

--- a/src/commands/sentinel-backlog/set-sequence.ts
+++ b/src/commands/sentinel-backlog/set-sequence.ts
@@ -1,0 +1,85 @@
+import { Args, Command, Options, Prompt } from '@effect/cli';
+import { Boolean, Console, Effect, Option, pipe } from 'effect';
+import { color } from '../../libs/console.ts';
+import { initializeUrl } from '../../index.js';
+import { SentinelBacklogService } from '../../services/sentinel-backlog.js';
+
+const validateParams = Effect.fn((value: Option.Option<string>, latest: boolean) => pipe(
+  value,
+  Option.isSome,
+  Boolean.xor(latest),
+  Effect.succeed,
+  Effect.filterOrFail(
+    valid => valid,
+    () => new Error('Must provide either the --latest flag or a value argument (but not both).')
+  )
+));
+
+const getNewSequenceValue = Effect.fn((value: Option.Option<string>) => pipe(
+  value,
+  Option.map(Effect.succeed),
+  Option.getOrElse(() => SentinelBacklogService.getMedicUpdateSeq()),
+));
+
+const getConfirmationPrompt = (currentTransitionSeq: string, newTransitionSeq: string) => Prompt.confirm({
+  message: `You are about to update the Sentinel transition sequence:
+  
+Current value: ${pipe(currentTransitionSeq, color('green'))}
+New value: ${pipe(newTransitionSeq, color('green'))}  
+
+Are you sure you want to make this update?`,
+  initial: false,
+});
+const isRemoveConfirmed = Effect.fn((yes: boolean, currentTransitionSeq: string, newTransitionSeq: string) => Effect
+  .succeed(true)
+  .pipe(Effect.filterOrElse(
+    () => yes,
+    () => getConfirmationPrompt(currentTransitionSeq, newTransitionSeq),
+  )));
+
+const value = Args
+  .text({ name: 'value' })
+  .pipe(
+    Args.withDescription(
+      'The sequence value to set. This is the target update-seq value from the medic database. '
+      + 'Required when --latest is not set.'
+    ),
+    Args.optional,
+  );
+
+const latest = Options
+  .boolean('latest')
+  .pipe(
+    Options.withDescription(
+      'Set the Sentinel transitions sequence value to the current update-seq value from the medic database. '
+      + 'Cannot be used when providing a value argument.'
+    ),
+  );
+
+const yes = Options
+  .boolean('yes')
+  .pipe(
+    Options.withAlias('y'),
+    Options.withDescription('Do not prompt for confirmation.'),
+  );
+
+export const setSequence = Command
+  .make('set-sequence', { value, latest, yes }, ({ value, latest, yes }) => initializeUrl.pipe(
+    Effect.andThen(validateParams(value, latest)),
+    Effect.andThen(Effect.all([
+      SentinelBacklogService.getTransitionsSeq(),
+      getNewSequenceValue(value)
+    ], { concurrency: 'unbounded' })),
+    Effect.flatMap(([currentSeq, newSeq]) => pipe(
+      isRemoveConfirmed(yes, currentSeq, newSeq),
+      Effect.map(removeConfirmed => Option.liftPredicate(
+        SentinelBacklogService.setTransitionsSeq(newSeq),
+        () => removeConfirmed
+      )),
+      Effect.flatMap(Option.getOrElse(() => Console.log('Operation cancelled'))),
+    ))
+  ))
+  .pipe(Command.withDescription(
+    'Update the Sentinel transitions sequence value. The Sentinel container should be stopped before '
+    + 'performing this operation and then started again once the update is complete.'
+  ));

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ import { instance } from './commands/instance/index.ts';
 import { LocalInstanceService } from './services/local-instance.ts';
 import { localIp } from './commands/local-ip/index.ts';
 import { LocalIpService } from './services/local-ip.ts';
+import { SentinelBacklogService } from './services/sentinel-backlog.js';
+import { sentinelBacklog } from './commands/sentinel-backlog/index.js';
 
 const url = Options
   .text('url')
@@ -54,7 +56,7 @@ export const initializeUrl = chtx.pipe(
 );
 
 const command = chtx.pipe(Command.withSubcommands([
-  design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance
+  design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance, sentinelBacklog
 ]));
 
 const cli = Command.run(command, {
@@ -77,6 +79,7 @@ cli(process.argv)
     Effect.provide(UpgradeService.Default),
     Effect.provide(WarmViewsService.Default),
     Effect.provide(ReplicateService.Default),
+    Effect.provide(SentinelBacklogService.Default),
     Effect.provide(TestDataGeneratorService.Default),
     Effect.provide(PouchDBService.Default),
     Effect.provide(ChtClientService.Default.pipe(httpClientNoSslVerify)),

--- a/src/libs/console.ts
+++ b/src/libs/console.ts
@@ -1,14 +1,14 @@
 import { Console, Effect, FiberRef, LogLevel, pipe } from 'effect';
 
-// const ANSI_CODES = {
-//   red: '\x1b[31m',
-//   green: '\x1b[32m',
-//   blue: '\x1b[34m'
-// };
-// type AnsiColor = keyof typeof ANSI_CODES;
-// const resetCode = '\x1b[0m';
+const ANSI_CODES = {
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  blue: '\x1b[34m'
+};
+type AnsiColor = keyof typeof ANSI_CODES;
+const resetCode = '\x1b[0m';
 
-// export const color = (color: AnsiColor) => (text: string): string => `${ANSI_CODES[color]}${text}${resetCode}`;
+export const color = (color: AnsiColor) => (text: string): string => `${ANSI_CODES[color]}${text}${resetCode}`;
 
 export const debugLoggingEnabled = FiberRef
   .get(FiberRef.currentMinimumLogLevel)

--- a/src/services/sentinel-backlog.ts
+++ b/src/services/sentinel-backlog.ts
@@ -1,0 +1,70 @@
+import * as Effect from 'effect/Effect';
+import * as Context from 'effect/Context';
+import { getDoc, PouchDBService, saveDoc } from './pouchdb.ts';
+import { Array, Option, pipe, Record, Schema } from 'effect';
+import { ChtClientService } from './cht-client.ts';
+import { getDbsInfoByName } from '../libs/couch/dbs-info.ts';
+
+class LocalTransitionsSeq extends Schema.Class<LocalTransitionsSeq>('LocalTransitionsSeq')({
+  value: Schema.String,
+}) {
+}
+
+const medicUpdateSeqEffect = Effect.suspend(() => pipe(
+  getDbsInfoByName(['medic']),
+  Effect.map(Array.unsafeGet(0)),
+  Effect.map(({ info }) => info.update_seq),
+  Effect.tap(updateSeq => Effect.logDebug(`medic update_seq: ${updateSeq}`)),
+));
+
+const localTransitionsSeqEffect = Effect.suspend( () => pipe(
+  '_local/transitions-seq',
+  getDoc('medic-sentinel'),
+  Effect.map(Option.flatMap(Schema.decodeUnknownOption(LocalTransitionsSeq, { onExcessProperty: 'preserve' }))),
+  Effect.map(Option.getOrThrowWith(() => new Error('No _local/transitions-seq doc found.'))),
+  Effect.tap(seq => Effect.logDebug(`local transitions seq: ${seq.value}`)),
+));
+
+const setLocalTransitionsSeq = Effect.fn((value: string) => pipe(
+  localTransitionsSeqEffect,
+  Effect.map(Record.set('value', value)),
+  Effect.flatMap(saveDoc('medic-sentinel')),
+  Effect.tap(() => Effect.logDebug(`Local transitions seq updated to ${value}`)),
+));
+
+const serviceContext = Effect
+  .all([
+    ChtClientService,
+    PouchDBService,
+  ])
+  .pipe(Effect.map(([
+    chtClient,
+    pouch,
+  ]) => Context
+    .make(PouchDBService, pouch)
+    .pipe(Context.add(ChtClientService, chtClient))));
+
+export class SentinelBacklogService extends Effect.Service<SentinelBacklogService>()(
+  'chtoolbox/SentinelBacklogService',
+  {
+    effect: serviceContext.pipe(Effect.map(context => ({
+      getMedicUpdateSeq: (): Effect.Effect<string, Error> => pipe(
+        medicUpdateSeqEffect,
+        Effect.provide(context),
+      ),
+      getTransitionsSeq: (): Effect.Effect<string, Error> => pipe(
+        localTransitionsSeqEffect,
+        Effect.map(({ value }) => value),
+        Effect.provide(context),
+      ),
+      setTransitionsSeq: (value: string): Effect.Effect<void, Error> => pipe(
+        setLocalTransitionsSeq(value),
+        Effect.mapError(x => x as unknown as Error),
+        Effect.asVoid,
+        Effect.provide(context),
+      ),
+    }))),
+    accessors: true,
+  }
+) {
+}

--- a/test/libs/console.spec.ts
+++ b/test/libs/console.spec.ts
@@ -2,22 +2,22 @@ import { describe, it } from 'mocha';
 import { Console, Effect, Logger, LogLevel, TestContext } from 'effect';
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { clearConsole, clearThen, debugLoggingEnabled, logJson } from '../../src/libs/console.ts';
+import { clearConsole, clearThen, debugLoggingEnabled, logJson, color } from '../../src/libs/console.ts';
 
 describe('Console libs', () => {
   const run = (test:  Effect.Effect<void, Error>) => async () => {
     await Effect.runPromise(test.pipe(Effect.provide(TestContext.TestContext)));
   };
 
-  // [
-  //   ['red', '\x1b[31m'],
-  //   ['green', '\x1b[32m'],
-  //   ['blue', '\x1b[34m']
-  // ].forEach(([ansiColor, expectedCode]) => {
-  //   it(`color(${ansiColor})`, () => {
-  //     expect(color(ansiColor as 'red' | 'green' | 'blue')('hello')).to.equal(`${expectedCode}hello\x1b[0m`);
-  //   });
-  // });
+  ([
+    ['red', '\x1b[31m'],
+    ['green', '\x1b[32m'],
+    ['blue', '\x1b[34m']
+  ] as [string, string][]).forEach(([ansiColor, expectedCode]) => {
+    it(`color(${ansiColor})`, () => {
+      expect(color(ansiColor as 'red' | 'green' | 'blue')('hello')).to.equal(`${expectedCode}hello\x1b[0m`);
+    });
+  });
 
   describe('debugLoggingEnabled', () => {
     it('returns true when DEBUG logging is enabled', run(Effect.gen(function* () {

--- a/test/services/sentinel-backlog.spec.ts
+++ b/test/services/sentinel-backlog.spec.ts
@@ -1,0 +1,105 @@
+import { describe, it } from 'mocha';
+import { Effect, Either, Layer, Option } from 'effect';
+import sinon, { type SinonStub } from 'sinon';
+import { PouchDBService } from '../../src/services/pouchdb.ts';
+import { expect } from 'chai';
+import * as SentinelBacklogSvc from '../../src/services/sentinel-backlog.ts';
+import { genWithLayer, sandbox } from '../utils/base.ts';
+import { ChtClientService } from '../../src/services/cht-client.ts';
+import esmock from 'esmock';
+import { createDbInfo } from '../utils/data-models.js';
+
+const getDbsInfoByName = sandbox.stub();
+const mockPouchSvc = {
+  getDoc: sandbox.stub(),
+  saveDoc: sandbox.stub(),
+};
+
+const { SentinelBacklogService } = await esmock<typeof SentinelBacklogSvc>(
+  '../../src/services/sentinel-backlog.ts',
+  {
+    '../../src/libs/couch/dbs-info.ts': { getDbsInfoByName },
+    '../../src/services/pouchdb.ts': mockPouchSvc,
+  }
+);
+const run = SentinelBacklogService.Default.pipe(
+  Layer.provide(Layer.succeed(PouchDBService, {} as unknown as PouchDBService)),
+  Layer.provide(Layer.succeed(ChtClientService, {} as unknown as ChtClientService)),
+  genWithLayer,
+);
+
+describe('Sentinel Backlog Service', () => {
+  let getDocInner: SinonStub;
+  beforeEach(() => {
+    getDocInner = sinon.stub();
+    mockPouchSvc.getDoc.returns(getDocInner);
+  });
+
+  it('getMedicUpdateSeq', run(function* () {
+    const update_seq = '123';
+    const dbInfo = createDbInfo({ key: 'medic', update_seq });
+    getDbsInfoByName.returns(Effect.succeed([dbInfo]));
+
+    const result = yield* SentinelBacklogService.getMedicUpdateSeq();
+
+    expect(result).to.equal(update_seq);
+    expect(getDbsInfoByName).to.have.been.calledOnceWithExactly(['medic']);
+    expect(mockPouchSvc.getDoc).to.not.have.been.called;
+    expect(mockPouchSvc.saveDoc).to.not.have.been.called;
+  }));
+
+  describe('getTransitionsSeq', () => {
+    afterEach(() => {
+      expect(mockPouchSvc.saveDoc).to.not.have.been.called;
+      expect(mockPouchSvc.getDoc).to.have.been.calledOnceWithExactly('medic-sentinel');
+      expect(getDocInner).to.have.been.calledOnceWithExactly('_local/transitions-seq');
+    });
+
+    it('returns sequence value', run(function* () {
+      const value = '456';
+      getDocInner.returns(Effect.succeed(Option.some({ value })));
+
+      const result = yield* SentinelBacklogService.getTransitionsSeq();
+
+      expect(result).to.equal(value);
+    }));
+
+    it('throws error when sequence value not found', run(function* () {
+      getDocInner.returns(Effect.succeed(Option.none()));
+
+      const either = yield* SentinelBacklogService
+        .getTransitionsSeq()
+        .pipe(
+          Effect.catchAllDefect(Effect.fail),
+          Effect.either
+        );
+
+      if (Either.isRight(either)) {
+        expect.fail('Expected error to be thrown.');
+      }
+
+      expect(either.left).to.deep.include(new Error('No _local/transitions-seq doc found.'));
+    }));
+  });
+
+  describe('setTransitionsSeq', () => {
+    let saveDocInner: SinonStub;
+    beforeEach(() => {
+      saveDocInner = sinon.stub();
+      mockPouchSvc.saveDoc.returns(saveDocInner);
+    });
+
+    it('returns sequence value', run(function* () {
+      const value = '456';
+      getDocInner.returns(Effect.succeed(Option.some({ value: '123', _rev: '1-abc' })));
+      saveDocInner.returns(Effect.void);
+
+      yield* SentinelBacklogService.setTransitionsSeq(value);
+
+      expect(mockPouchSvc.getDoc).to.have.been.calledOnceWithExactly('medic-sentinel');
+      expect(getDocInner).to.have.been.calledOnceWithExactly('_local/transitions-seq');
+      expect(mockPouchSvc.saveDoc).to.have.been.calledOnceWithExactly('medic-sentinel');
+      expect(saveDocInner).to.have.been.calledOnceWithExactly({ value, _rev: '1-abc' });
+    }));
+  });
+});


### PR DESCRIPTION
Closes: https://github.com/jkuester/chtoolbox/issues/165

This PR adds support for several new commands:

- `sentinel-backlog ls`  - Prints details about the current Sentinel backlog (including current sequence versions)
- `sentinel-backlog set-sequence` - Updates the current Sentinel transition sequence.

## `set-sequence`

The `chtx sentinel-backlog set-sequence` command is useful in situations such as:

- The Sentinel transition sequence on your CHT instance was somehow removed or set to an unexpected value (e.g. reset back to `0`).
- You are migrating/generating a lot of data on a test instance and you do not want to run Sentinel transitions on all the changes.

In any case, the `set-sequence` command can be used to adjust the sequence. You can provide the exact update-seq value to use or you can set the `--latest` flag to automatically populate the transition sequence with the latest `update-seq` value from the `medic` database (effectively resetting your Sentinel backlog to `0`).

Before running the `set-sequence` command, you MUST manually stop the Sentinel container. Then, once the  `set-sequence` command completes, you can restart the Sentinel container and it will begin processing changes from the provided sequence value.  