### PR TITLE
feat: support `update-password-change-required` command

### DIFF
--- a/dist/commands/update-password-change-required.js
+++ b/dist/commands/update-password-change-required.js
@@ -1,0 +1,7 @@
+import { Command } from '@effect/cli';
+import { Console, Effect, pipe, Stream } from 'effect';
+import { initializeUrl } from "../index.js";
+import { UserPermissionsService } from '../services/user-permissions.js';
+export const updatePasswordChangeRequired = Command
+    .make('update-password-change-required', {}, () => pipe(initializeUrl, Effect.andThen(UserPermissionsService.updatePasswordChangeRequired()), Effect.map(Stream.tap(Console.log)), Effect.flatMap(Stream.runDrain)))
+    .pipe(Command.withDescription('Sets `password_change_required = false` for any users that have the can_skip_password_change permission.'));

--- a/dist/index.js
+++ b/dist/index.js
@@ -27,6 +27,8 @@ import { localIp } from "./commands/local-ip/index.js";
 import { LocalIpService } from "./services/local-ip.js";
 import { SentinelBacklogService } from './services/sentinel-backlog.js';
 import { sentinelBacklog } from './commands/sentinel-backlog/index.js';
+import { updatePasswordChangeRequired } from './commands/update-password-change-required.js';
+import { UserPermissionsService } from './services/user-permissions.js';
 const url = Options
     .text('url')
     .pipe(Options.withDescription('The URL of the CouchDB server. Defaults to the COUCH_URL environment variable. Note that since this tool is ' +
@@ -36,7 +38,8 @@ const setEnv = (url) => Effect.flatMap(EnvironmentService, envSvc => envSvc.setU
 const getEnv = Effect.flatMap(EnvironmentService, envSvc => envSvc.get());
 export const initializeUrl = chtx.pipe(Effect.map(({ url }) => url), Effect.map(Option.map(Redacted.make)), Effect.map(Option.map(setEnv)), Effect.flatMap(Option.getOrElse(() => getEnv)), Effect.map(({ url }) => Redacted.value(url)), Effect.map(Option.liftPredicate(String.isNonEmpty)), Effect.map(Option.getOrThrowWith(() => new Error('A value must be set for the COUCH_URL envar or the --url option.'))));
 const command = chtx.pipe(Command.withSubcommands([
-    design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance, sentinelBacklog
+    design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance, sentinelBacklog,
+    updatePasswordChangeRequired
 ]));
 const cli = Command.run(command, {
     name: 'CHT Toolbox',
@@ -44,4 +47,4 @@ const cli = Command.run(command, {
 });
 const httpClientNoSslVerify = Layer.provide(NodeHttpClient.layerWithoutAgent.pipe(Layer.provide(NodeHttpClient.makeAgentLayer({ rejectUnauthorized: false }))));
 cli(process.argv)
-    .pipe(Effect.provide(CompactService.Default), Effect.provide(MonitorService.Default), Effect.provide(LocalDiskUsageService.Default), Effect.provide(LocalInstanceService.Default.pipe(httpClientNoSslVerify)), Effect.provide(LocalIpService.Default), Effect.provide(PurgeService.Default), Effect.provide(UpgradeService.Default), Effect.provide(WarmViewsService.Default), Effect.provide(ReplicateService.Default), Effect.provide(SentinelBacklogService.Default), Effect.provide(TestDataGeneratorService.Default), Effect.provide(PouchDBService.Default), Effect.provide(ChtClientService.Default.pipe(httpClientNoSslVerify)), Effect.provide(EnvironmentService.Default), Effect.provide(NodeContext.layer), NodeRuntime.runMain);
+    .pipe(Effect.provide(UserPermissionsService.Default), Effect.provide(CompactService.Default), Effect.provide(MonitorService.Default), Effect.provide(LocalDiskUsageService.Default), Effect.provide(LocalInstanceService.Default.pipe(httpClientNoSslVerify)), Effect.provide(LocalIpService.Default), Effect.provide(PurgeService.Default), Effect.provide(UpgradeService.Default), Effect.provide(WarmViewsService.Default), Effect.provide(ReplicateService.Default), Effect.provide(SentinelBacklogService.Default), Effect.provide(TestDataGeneratorService.Default), Effect.provide(PouchDBService.Default), Effect.provide(ChtClientService.Default.pipe(httpClientNoSslVerify)), Effect.provide(EnvironmentService.Default), Effect.provide(NodeContext.layer), NodeRuntime.runMain);

--- a/dist/services/pouchdb.js
+++ b/dist/services/pouchdb.js
@@ -1,6 +1,6 @@
 import * as Effect from 'effect/Effect';
 import * as Context from 'effect/Context';
-import { Chunk, Match, Option, pipe, Redacted, Stream, StreamEmit, String } from 'effect';
+import { Chunk, Match, Option, pipe, Redacted, Stream, StreamEmit, String, Array } from 'effect';
 import PouchDB from 'pouchdb-core';
 import { pouchDB } from "../libs/core.js";
 import PouchDBAdapterHttp from 'pouchdb-adapter-http';
@@ -39,15 +39,9 @@ export const streamAllDocPages = (dbName) => (options = {}) => PouchDBService
 //     Effect.map(Array.map(({ doc }) => doc)),
 //     Effect.map(Array.filter(Predicate.isNotNullable)),
 //   );
-// const bulkDocs = (dbName: string) => (
-//   docs: PouchDB.Core.PutDocument<object>[]
-// ) => PouchDBService
-//     .get(dbName)
-//     .pipe(
-//       Effect.flatMap(db => Effect.promise(() => db.bulkDocs(docs))),
-//       Effect.map(Array.map(getPouchResponse)),
-//       Effect.flatMap(Effect.all),
-//     );
+export const bulkDocs = (dbName) => Effect.fn((docs) => PouchDBService
+    .get(dbName)
+    .pipe(Effect.flatMap(db => Effect.promise(() => db.bulkDocs(docs))), Effect.map(Array.map(getPouchResponse)), Effect.flatMap(Effect.all)));
 //
 // export const deleteDocs = (dbName: string) => (
 //   docs: NonEmptyArray<Doc>

--- a/dist/services/user-permissions.js
+++ b/dist/services/user-permissions.js
@@ -1,0 +1,41 @@
+import * as Effect from 'effect/Effect';
+import * as Context from 'effect/Context';
+import { bulkDocs, getDoc, PouchDBService, streamAllDocPages } from "./pouchdb.js";
+import { Array, Option, pipe, Predicate, Schema, Stream } from 'effect';
+import { ChtClientService } from "./cht-client.js";
+class UserDoc extends Schema.Class('UserDoc')({
+    _id: Schema.String,
+    password_change_required: Schema.UndefinedOr(Schema.Boolean),
+    roles: Schema.Array(Schema.String),
+}) {
+}
+class ChtSettings extends Schema.Class('ChtSettings')({
+    settings: Schema.Struct({
+        permissions: Schema.Struct({
+            can_skip_password_change: Schema.UndefinedOr(Schema.Array(Schema.String)),
+        })
+    })
+}) {
+}
+const hasPasswordChangeRequired = ({ password_change_required }) => Predicate
+    .isTruthy(password_change_required);
+const cachedCanSkipPasswordChangeRoles = pipe('settings', getDoc('medic'), Effect.tap(Effect.logDebug('Retrieved settings doc')), Effect.map(Option.flatMap(Schema.decodeUnknownOption(ChtSettings))), Effect.map(Option.map(({ settings: { permissions: { can_skip_password_change } } }) => can_skip_password_change)), Effect.map(Option.flatMap(Option.fromNullable)), Effect.map(Option.getOrElse(() => [])), Effect.cached);
+const hasCanSkipPasswordChangePermission = (canSkipRoles) => ({ roles }) => pipe(canSkipRoles, Effect.map(Array.intersection(roles)), Effect.map(Array.isNonEmptyArray));
+const updateUsersPasswordChangeRequired = (users) => pipe(users, Array.map(doc => ({ ...doc, password_change_required: false })), bulkDocs('_users'), Effect.map(Array.map(({ id }) => id)), Effect.tap(ids => Effect.logDebug(`Updated password_change_required for ${ids.length.toString()} users`)));
+const decodeUserDoc = (doc) => pipe(doc, Schema.decodeUnknownOption(UserDoc, { onExcessProperty: 'preserve' }));
+const updateUsers = (canSkipRoles) => pipe({ include_docs: true }, streamAllDocPages('_users'), Effect.map(Stream.map(({ rows }) => rows)), Effect.map(Stream.map(Array.map(({ doc }) => doc))), Effect.map(Stream.map(Array.map(decodeUserDoc))), Effect.map(Stream.map(Array.map(Option.filter(hasPasswordChangeRequired)))), Effect.map(Stream.map(Array.map(Option.getOrUndefined))), Effect.map(Stream.map(Array.filter(Predicate.isNotNullable))), Effect.map(Stream.mapEffect(Effect.filter(hasCanSkipPasswordChangePermission(canSkipRoles)))), Effect.map(Stream.mapEffect(updateUsersPasswordChangeRequired)), Effect.map(Stream.flattenIterables));
+const serviceContext = Effect
+    .all([
+    ChtClientService,
+    PouchDBService,
+])
+    .pipe(Effect.map(([chtClient, pouch,]) => Context
+    .make(PouchDBService, pouch)
+    .pipe(Context.add(ChtClientService, chtClient))));
+export class UserPermissionsService extends Effect.Service()('chtoolbox/UserPermissionsService', {
+    effect: serviceContext.pipe(Effect.map(context => ({
+        updatePasswordChangeRequired: Effect.fn(() => pipe(cachedCanSkipPasswordChangeRoles, Effect.flatMap(updateUsers), Effect.map(Stream.mapError(x => x)), Effect.map(Stream.provideContext(context)), Effect.provide(context))),
+    }))),
+    accessors: true,
+}) {
+}

--- a/src/commands/update-password-change-required.ts
+++ b/src/commands/update-password-change-required.ts
@@ -1,0 +1,15 @@
+import { Command } from '@effect/cli';
+import { Console, Effect, pipe, Stream } from 'effect';
+import { initializeUrl } from '../index.ts';
+import { UserPermissionsService } from '../services/user-permissions.js';
+
+export const updatePasswordChangeRequired = Command
+  .make('update-password-change-required', {}, () => pipe(
+    initializeUrl,
+    Effect.andThen(UserPermissionsService.updatePasswordChangeRequired()),
+    Effect.map(Stream.tap(Console.log)),
+    Effect.flatMap(Stream.runDrain),
+  ))
+  .pipe(Command.withDescription(
+    'Sets `password_change_required = false` for any users that have the can_skip_password_change permission.'
+  ));

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,8 @@ import { localIp } from './commands/local-ip/index.ts';
 import { LocalIpService } from './services/local-ip.ts';
 import { SentinelBacklogService } from './services/sentinel-backlog.js';
 import { sentinelBacklog } from './commands/sentinel-backlog/index.js';
+import { updatePasswordChangeRequired } from './commands/update-password-change-required.js';
+import { UserPermissionsService } from './services/user-permissions.js';
 
 const url = Options
   .text('url')
@@ -56,7 +58,8 @@ export const initializeUrl = chtx.pipe(
 );
 
 const command = chtx.pipe(Command.withSubcommands([
-  design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance, sentinelBacklog
+  design, doc, localIp, monitor, warmViews, activeTasks, db, upgrade, instance, sentinelBacklog,
+  updatePasswordChangeRequired
 ]));
 
 const cli = Command.run(command, {
@@ -70,6 +73,7 @@ const httpClientNoSslVerify = Layer.provide(NodeHttpClient.layerWithoutAgent.pip
 
 cli(process.argv)
   .pipe(
+    Effect.provide(UserPermissionsService.Default),
     Effect.provide(CompactService.Default),
     Effect.provide(MonitorService.Default),
     Effect.provide(LocalDiskUsageService.Default),

--- a/src/services/pouchdb.ts
+++ b/src/services/pouchdb.ts
@@ -1,6 +1,6 @@
 import * as Effect from 'effect/Effect';
 import * as Context from 'effect/Context';
-import { Chunk, Match, Option, pipe, Redacted, Stream, StreamEmit, String } from 'effect';
+import { Chunk, Match, Option, pipe, Redacted, Stream, StreamEmit, String, Array } from 'effect';
 import PouchDB from 'pouchdb-core';
 import { pouchDB } from '../libs/core.ts';
 import PouchDBAdapterHttp from 'pouchdb-adapter-http';
@@ -71,15 +71,19 @@ type Doc = PouchDB.Core.AllDocsMeta & PouchDB.Core.IdMeta & PouchDB.Core.Revisio
 //     Effect.map(Array.filter(Predicate.isNotNullable)),
 //   );
 
-// const bulkDocs = (dbName: string) => (
-//   docs: PouchDB.Core.PutDocument<object>[]
-// ) => PouchDBService
-//     .get(dbName)
-//     .pipe(
-//       Effect.flatMap(db => Effect.promise(() => db.bulkDocs(docs))),
-//       Effect.map(Array.map(getPouchResponse)),
-//       Effect.flatMap(Effect.all),
-//     );
+export const bulkDocs = (
+  dbName: string
+): (
+  docs: PouchDB.Core.PutDocument<object>[]
+) => Effect.Effect<PouchDB.Core.Response[], PouchDB.Core.Error, PouchDBService> => Effect.fn((
+  docs
+) => PouchDBService
+  .get(dbName)
+  .pipe(
+    Effect.flatMap(db => Effect.promise(() => db.bulkDocs(docs))),
+    Effect.map(Array.map(getPouchResponse)),
+    Effect.flatMap(Effect.all),
+  ));
 //
 // export const deleteDocs = (dbName: string) => (
 //   docs: NonEmptyArray<Doc>

--- a/src/services/user-permissions.ts
+++ b/src/services/user-permissions.ts
@@ -1,0 +1,171 @@
+import * as Effect from 'effect/Effect';
+import * as Context from 'effect/Context';
+import { type AllDocsResponseStream, getDoc, PouchDBService, streamAllDocPages, streamQueryPages } from './pouchdb.ts';
+import { Array, Option, pipe, Predicate, Schema, Stream, String, Record } from 'effect';
+import { purgeFrom } from '../libs/couch/purge.ts';
+import { ChtClientService } from './cht-client.ts';
+import { ReadonlyArray } from 'effect/Array';
+type AllDocsResponse = PouchDB.Core.AllDocsResponse<object>;
+type AllDocsWithKeysResponse = PouchDB.Core.AllDocsWithKeysResponse<object>;
+
+// _purge endpoint only accepts batches of 100.
+// skip: 0 just keeps getting the next 100 (after the last was purged)
+const PAGE_OPTIONS = { limit: 100, skip: 0 };
+
+const AllDocsRow = Schema.Struct({ id: Schema.String, value: Schema.Struct({ rev: Schema.String }) });
+const convertAllDocsResponse = (response: AllDocsResponse | AllDocsWithKeysResponse) => pipe(
+  response.rows as unknown[],
+  Array.filter(Schema.is(AllDocsRow)),
+  Array.map(({ id, value: { rev } }) => ({ _id: id, _rev: rev }))
+);
+
+const filterDdoc = (purgeDdocs: boolean) => (doc: { _id: string }) => Option
+  .liftPredicate(doc, () => !purgeDdocs)
+  .pipe(
+    Option.map(({ _id }) => _id),
+    Option.map(Predicate.not(String.startsWith('_design/'))),
+    Option.getOrElse(() => true),
+  );
+
+const purgeRows = (dbName: string) => (rows: { _id: string, _rev: string }[]) => Option
+  .liftPredicate(rows, Array.isNonEmptyArray)
+  .pipe(
+    Option.map(purgeFrom(dbName)),
+    Option.map(Effect.andThen(Effect.void)),
+    Option.getOrElse(() => Effect.void),
+  );
+
+const getReportQueryOptions = (
+  { since, before }: { since: Option.Option<Date>, before: Option.Option<Date> },
+) => ({
+  ...PAGE_OPTIONS,
+  startkey: since.pipe(
+    Option.map(date => [date.getTime()]),
+    Option.getOrUndefined,
+  ),
+  endkey: before.pipe(
+    Option.map(date => [date.getTime()]),
+    Option.getOrUndefined,
+  ),
+});
+
+const getAllDocs = (dbName: string) => (keys: string[]) => PouchDBService
+  .get(dbName)
+  .pipe(Effect.flatMap(db => Effect.promise(() => db.allDocs({ keys }))));
+
+const purgeDocsFromResponse = (dbName: string) => (response: PouchDB.Query.Response<object>) => pipe(
+  response.rows,
+  Array.map(({ id }) => id as string),
+  getAllDocs(dbName),
+  Effect.map(convertAllDocsResponse),
+  Effect.flatMap(purgeRows(dbName)),
+);
+
+const purgeByViewQuery = (dbName: string, viewName: string) => (
+  opts: PouchDB.Query.Options<object, object>
+) => pipe(
+  opts,
+  streamQueryPages(dbName, viewName),
+  Effect.map(Stream.tap(purgeDocsFromResponse(dbName))),
+);
+
+class UserDoc extends Schema.Class<UserDoc>('UserDoc')({
+  _id: Schema.String,
+  password_change_required: Schema.UndefinedOr(Schema.Boolean),
+  roles: Schema.Array(Schema.String),
+}) {
+}
+
+class ChtSettings extends Schema.Class<ChtSettings>('ChtSettings')({
+  permissions: Schema.Struct({
+    can_skip_password_change: Schema.UndefinedOr(Schema.Array(Schema.String)),
+  })
+}) {
+}
+
+const hasPasswordChangeRequired = ({ password_change_required }: UserDoc) => Predicate
+  .isTruthy(password_change_required);
+
+const canSkipPasswordChangeRolesEffect = Effect.cached(pipe(
+  'settings',
+  getDoc('medic'),
+  Effect.tap(Effect.logDebug('Retrieved settings doc')),
+  Effect.map(Option.flatMap(Schema.decodeUnknownOption(ChtSettings))),
+  Effect.map(Option.map(({  permissions }) => permissions.can_skip_password_change)),
+  Effect.map(Option.flatMap(Option.fromNullable)),
+  Effect.map(Option.getOrElse(() => [] as string[])),
+));
+
+const hasCanSkipPasswordChangePermission = ({ roles }: UserDoc) => pipe(
+  canSkipPasswordChangeRolesEffect,
+  Effect.flatten,
+  Effect.map(Array.union(roles)),
+  Effect.map(Array.isNonEmptyArray),
+);
+
+const getAllUsers = pipe(
+  { include_docs: true },
+  streamAllDocPages('_users'),
+  Effect.map(Stream.map(({ rows }) => rows)),
+  Effect.map(Stream.map(Array.map(({ doc }) => Schema.decodeUnknownOption(UserDoc)(doc)))),
+  Effect.map(Stream.map(Array.map(Option.filter(hasPasswordChangeRequired)))),
+  Effect.map(Stream.map(Array.map(Option.getOrUndefined))),
+  Effect.map(Stream.map(Array.filter(Predicate.isNotNullable))),
+  Effect.map(Stream.map(Effect.filter(hasCanSkipPasswordChangePermission))),
+  // Effect.map(Stream.map(Array.map(Option.filter(hasCanSkipPasswordChangePermission)))),
+  x => x,
+);
+
+/*
+ * Get users with password_change_required = true.
+ *  - For each, check if they have can_skip_password_change permission
+ *  - If so, set password_change_required = false
+ */
+
+const serviceContext = Effect
+  .all([
+    ChtClientService,
+    PouchDBService,
+  ])
+  .pipe(Effect.map(([
+    chtClient,
+    pouch,
+  ]) => Context
+    .make(PouchDBService, pouch)
+    .pipe(Context.add(ChtClientService, chtClient))));
+
+export class PurgeService extends Effect.Service<PurgeService>()('chtoolbox/PurgeService', {
+  effect: serviceContext.pipe(Effect.map(context => ({
+    purgeAll: (dbName: string, purgeDdocs = false): Effect.Effect<AllDocsResponseStream, Error> => pipe(
+      PAGE_OPTIONS,
+      streamAllDocPages(dbName),
+      Effect.map(Stream.tap(response => pipe(
+        convertAllDocsResponse(response),
+        Array.filter(filterDdoc(purgeDdocs)),
+        purgeRows(dbName),
+      ))),
+      Effect.map(Stream.provideContext(context)),
+      Effect.provide(context),
+    ),
+    purgeReports: (
+      dbName: string,
+      opts: { since: Option.Option<Date>, before: Option.Option<Date> }
+    ): Effect.Effect<AllDocsResponseStream, Error> => pipe(
+      getReportQueryOptions(opts),
+      purgeByViewQuery(dbName, 'medic-client/reports_by_date'),
+      Effect.map(Stream.provideContext(context)),
+      Effect.provide(context),
+    ),
+    purgeContacts: (
+      dbName: string,
+      type: string,
+    ): Effect.Effect<AllDocsResponseStream, Error> => pipe(
+      { ...PAGE_OPTIONS, key: [type] },
+      purgeByViewQuery(dbName, 'medic-client/contacts_by_type'),
+      Effect.map(Stream.provideContext(context)),
+      Effect.provide(context),
+    )
+  }))),
+  accessors: true,
+}) {
+}

--- a/src/services/user-permissions.ts
+++ b/src/services/user-permissions.ts
@@ -1,73 +1,9 @@
 import * as Effect from 'effect/Effect';
 import * as Context from 'effect/Context';
-import { type AllDocsResponseStream, getDoc, PouchDBService, streamAllDocPages, streamQueryPages } from './pouchdb.ts';
-import { Array, Option, pipe, Predicate, Schema, Stream, String, Record } from 'effect';
-import { purgeFrom } from '../libs/couch/purge.ts';
+import { bulkDocs, getDoc, PouchDBService, streamAllDocPages } from './pouchdb.ts';
+import { Array, Option, pipe, Predicate, Schema, Stream } from 'effect';
 import { ChtClientService } from './cht-client.ts';
-import { ReadonlyArray } from 'effect/Array';
-type AllDocsResponse = PouchDB.Core.AllDocsResponse<object>;
-type AllDocsWithKeysResponse = PouchDB.Core.AllDocsWithKeysResponse<object>;
-
-// _purge endpoint only accepts batches of 100.
-// skip: 0 just keeps getting the next 100 (after the last was purged)
-const PAGE_OPTIONS = { limit: 100, skip: 0 };
-
-const AllDocsRow = Schema.Struct({ id: Schema.String, value: Schema.Struct({ rev: Schema.String }) });
-const convertAllDocsResponse = (response: AllDocsResponse | AllDocsWithKeysResponse) => pipe(
-  response.rows as unknown[],
-  Array.filter(Schema.is(AllDocsRow)),
-  Array.map(({ id, value: { rev } }) => ({ _id: id, _rev: rev }))
-);
-
-const filterDdoc = (purgeDdocs: boolean) => (doc: { _id: string }) => Option
-  .liftPredicate(doc, () => !purgeDdocs)
-  .pipe(
-    Option.map(({ _id }) => _id),
-    Option.map(Predicate.not(String.startsWith('_design/'))),
-    Option.getOrElse(() => true),
-  );
-
-const purgeRows = (dbName: string) => (rows: { _id: string, _rev: string }[]) => Option
-  .liftPredicate(rows, Array.isNonEmptyArray)
-  .pipe(
-    Option.map(purgeFrom(dbName)),
-    Option.map(Effect.andThen(Effect.void)),
-    Option.getOrElse(() => Effect.void),
-  );
-
-const getReportQueryOptions = (
-  { since, before }: { since: Option.Option<Date>, before: Option.Option<Date> },
-) => ({
-  ...PAGE_OPTIONS,
-  startkey: since.pipe(
-    Option.map(date => [date.getTime()]),
-    Option.getOrUndefined,
-  ),
-  endkey: before.pipe(
-    Option.map(date => [date.getTime()]),
-    Option.getOrUndefined,
-  ),
-});
-
-const getAllDocs = (dbName: string) => (keys: string[]) => PouchDBService
-  .get(dbName)
-  .pipe(Effect.flatMap(db => Effect.promise(() => db.allDocs({ keys }))));
-
-const purgeDocsFromResponse = (dbName: string) => (response: PouchDB.Query.Response<object>) => pipe(
-  response.rows,
-  Array.map(({ id }) => id as string),
-  getAllDocs(dbName),
-  Effect.map(convertAllDocsResponse),
-  Effect.flatMap(purgeRows(dbName)),
-);
-
-const purgeByViewQuery = (dbName: string, viewName: string) => (
-  opts: PouchDB.Query.Options<object, object>
-) => pipe(
-  opts,
-  streamQueryPages(dbName, viewName),
-  Effect.map(Stream.tap(purgeDocsFromResponse(dbName))),
-);
+import type { UnknownException } from 'effect/Cause';
 
 class UserDoc extends Schema.Class<UserDoc>('UserDoc')({
   _id: Schema.String,
@@ -77,8 +13,10 @@ class UserDoc extends Schema.Class<UserDoc>('UserDoc')({
 }
 
 class ChtSettings extends Schema.Class<ChtSettings>('ChtSettings')({
-  permissions: Schema.Struct({
-    can_skip_password_change: Schema.UndefinedOr(Schema.Array(Schema.String)),
+  settings: Schema.Struct({
+    permissions: Schema.Struct({
+      can_skip_password_change: Schema.UndefinedOr(Schema.Array(Schema.String)),
+    })
   })
 }) {
 }
@@ -86,41 +24,53 @@ class ChtSettings extends Schema.Class<ChtSettings>('ChtSettings')({
 const hasPasswordChangeRequired = ({ password_change_required }: UserDoc) => Predicate
   .isTruthy(password_change_required);
 
-const canSkipPasswordChangeRolesEffect = Effect.cached(pipe(
+const cachedCanSkipPasswordChangeRoles: Effect.Effect<CanSkipPasswordRoles> = pipe(
   'settings',
   getDoc('medic'),
   Effect.tap(Effect.logDebug('Retrieved settings doc')),
   Effect.map(Option.flatMap(Schema.decodeUnknownOption(ChtSettings))),
-  Effect.map(Option.map(({  permissions }) => permissions.can_skip_password_change)),
+  Effect.map(Option.map(({ settings: { permissions: { can_skip_password_change } } }) => can_skip_password_change)),
   Effect.map(Option.flatMap(Option.fromNullable)),
   Effect.map(Option.getOrElse(() => [] as string[])),
-));
+  Effect.cached
+);
 
-const hasCanSkipPasswordChangePermission = ({ roles }: UserDoc) => pipe(
-  canSkipPasswordChangeRolesEffect,
-  Effect.flatten,
-  Effect.map(Array.union(roles)),
+type CanSkipPasswordRoles = Effect.Effect<string[] | readonly string[], UnknownException, PouchDBService>;
+
+const hasCanSkipPasswordChangePermission = (
+  canSkipRoles: CanSkipPasswordRoles
+) => ({ roles }: UserDoc) => pipe(
+  canSkipRoles,
+  Effect.map(Array.intersection(roles)),
   Effect.map(Array.isNonEmptyArray),
 );
 
-const getAllUsers = pipe(
+const updateUsersPasswordChangeRequired = (users: UserDoc[]) => pipe(
+  users,
+  Array.map(doc => ({ ...doc, password_change_required: false })),
+  bulkDocs('_users'),
+  Effect.map(Array.map(({ id }) => id)),
+  Effect.tap(ids => Effect.logDebug(`Updated password_change_required for ${ids.length.toString()} users`)),
+);
+
+const decodeUserDoc = (doc: unknown) => pipe(
+  doc,
+  Schema.decodeUnknownOption(UserDoc, { onExcessProperty: 'preserve' })
+);
+
+const updateUsers = (canSkipRoles: CanSkipPasswordRoles) => pipe(
   { include_docs: true },
   streamAllDocPages('_users'),
   Effect.map(Stream.map(({ rows }) => rows)),
-  Effect.map(Stream.map(Array.map(({ doc }) => Schema.decodeUnknownOption(UserDoc)(doc)))),
+  Effect.map(Stream.map(Array.map(({ doc }) => doc))),
+  Effect.map(Stream.map(Array.map(decodeUserDoc))),
   Effect.map(Stream.map(Array.map(Option.filter(hasPasswordChangeRequired)))),
   Effect.map(Stream.map(Array.map(Option.getOrUndefined))),
   Effect.map(Stream.map(Array.filter(Predicate.isNotNullable))),
-  Effect.map(Stream.map(Effect.filter(hasCanSkipPasswordChangePermission))),
-  // Effect.map(Stream.map(Array.map(Option.filter(hasCanSkipPasswordChangePermission)))),
-  x => x,
+  Effect.map(Stream.mapEffect(Effect.filter(hasCanSkipPasswordChangePermission(canSkipRoles)))),
+  Effect.map(Stream.mapEffect(updateUsersPasswordChangeRequired)),
+  Effect.map(Stream.flattenIterables),
 );
-
-/*
- * Get users with password_change_required = true.
- *  - For each, check if they have can_skip_password_change permission
- *  - If so, set password_change_required = false
- */
 
 const serviceContext = Effect
   .all([
@@ -134,38 +84,19 @@ const serviceContext = Effect
     .make(PouchDBService, pouch)
     .pipe(Context.add(ChtClientService, chtClient))));
 
-export class PurgeService extends Effect.Service<PurgeService>()('chtoolbox/PurgeService', {
-  effect: serviceContext.pipe(Effect.map(context => ({
-    purgeAll: (dbName: string, purgeDdocs = false): Effect.Effect<AllDocsResponseStream, Error> => pipe(
-      PAGE_OPTIONS,
-      streamAllDocPages(dbName),
-      Effect.map(Stream.tap(response => pipe(
-        convertAllDocsResponse(response),
-        Array.filter(filterDdoc(purgeDdocs)),
-        purgeRows(dbName),
-      ))),
-      Effect.map(Stream.provideContext(context)),
-      Effect.provide(context),
-    ),
-    purgeReports: (
-      dbName: string,
-      opts: { since: Option.Option<Date>, before: Option.Option<Date> }
-    ): Effect.Effect<AllDocsResponseStream, Error> => pipe(
-      getReportQueryOptions(opts),
-      purgeByViewQuery(dbName, 'medic-client/reports_by_date'),
-      Effect.map(Stream.provideContext(context)),
-      Effect.provide(context),
-    ),
-    purgeContacts: (
-      dbName: string,
-      type: string,
-    ): Effect.Effect<AllDocsResponseStream, Error> => pipe(
-      { ...PAGE_OPTIONS, key: [type] },
-      purgeByViewQuery(dbName, 'medic-client/contacts_by_type'),
-      Effect.map(Stream.provideContext(context)),
-      Effect.provide(context),
-    )
-  }))),
-  accessors: true,
-}) {
+export class UserPermissionsService extends Effect.Service<UserPermissionsService>()(
+  'chtoolbox/UserPermissionsService',
+  {
+    effect: serviceContext.pipe(Effect.map(context => ({
+      updatePasswordChangeRequired: Effect.fn((): Effect.Effect<Stream.Stream<string, Error>> => pipe(
+        cachedCanSkipPasswordChangeRoles,
+        Effect.flatMap(updateUsers),
+        Effect.map(Stream.mapError(x => x as unknown as Error)),
+        Effect.map(Stream.provideContext(context)),
+        Effect.provide(context),
+      )),
+    }))),
+    accessors: true,
+  }
+) {
 }


### PR DESCRIPTION
This branch contains a `update-password-change-required` utility script. I currently do not plan to merge this to `main` unless it becomes clear that it is more broadly useful.  

Regardless, the script can be executed directly from this branch with the following command:

```shell
npx -y git+https://github.com/jkuester/chtoolbox.git#password_change_required update-password-change-required
```

---

## Functionality

The purpose of this script is to "fix" users that have the `can_skip_password_change` permission, but are currently still required to reset their password on next login. This can happen when the user's password is set (e.g. at creation) , but the user did not have the `can_skip_password_change` permission. Then, at a later time, the user's roles were updated so they not have that permission. In this case, the current CHT logic will still require the user to change their password (since the `password_change_required` field on their `_users` doc is still set to `true`).  

This script parses all the user documents and checks the roles of any that currently have `password_change_required: true`.  If the user now has the `can_skip_password_change` permission (based on their current roles), it sets `password_change_required: true` for that user.

Users are processed in batches of 1000, and the usernames of updated users are logged to the console.