### PR TITLE
fix: update `tsx` reference in shim file to reference full path

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -3,6 +3,7 @@
 import { spawnSync } from 'node:child_process';
 import { resolve, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
+const tsxPath = fileURLToPath(import.meta.resolve('tsx'));
 
 /**
  * This file is a shim for running the TS directly as a bin script.
@@ -14,7 +15,7 @@ const result = spawnSync(
   'node',
   [
     '--import',
-    'tsx',
+    tsxPath,
     entry,
     ...process.argv.slice(2)
   ],


### PR DESCRIPTION
This fixes the issue of being able to run outside a directory with tsx already installed.