### PR TITLE
feat: add support for loading config values from JSON config file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@octokit/plugin-paginate-rest": "^13.1.1",
         "@octokit/rest": "^21.0.0",
         "effect": "^3.17.9",
+        "env-paths": "^3.0.0",
         "get-port": "^7.1.0",
         "pouchdb-adapter-http": "^9.0.0",
         "pouchdb-core": "^9.0.0",
@@ -3305,6 +3306,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/esbuild": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@octokit/plugin-paginate-rest": "^13.1.1",
     "@octokit/rest": "^21.0.0",
     "effect": "^3.17.9",
+    "env-paths": "^3.0.0",
     "get-port": "^7.1.0",
     "pouchdb-adapter-http": "^9.0.0",
     "pouchdb-core": "^9.0.0",

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -109,7 +109,7 @@ const diff = Options
     Options.withDescription(
       'Show diff between the given CHT version and the target version. No changes will be made. This option is for '
       + 'comparing arbitrary CHT versions. Use the --preview option to compare the current version of your CHT '
-      + 'instance with the target version. The GITHUB_TOKEN environment variable must be set when performing this '
+      + 'instance with the target version. The GITHUB_TOKEN config option must be set when performing this '
       + 'operation. The token must at least have read-only access to public repositories.'
     ),
     Options.optional
@@ -119,8 +119,8 @@ const preview = Options
   .boolean('preview')
   .pipe(Options.withDescription(
     'Show diff between the current CHT version and the targeted upgrade version. No changes will be made. Use the '
-    + '--diff option to compare arbitrary CHT versions without a CHT instance in context. The GITHUB_TOKEN environment '
-    + 'variable must be set when performing this operation. The token must at least have read-only access to public '
+    + '--diff option to compare arbitrary CHT versions without a CHT instance in context. The GITHUB_TOKEN config '
+    + 'option must be set when performing this operation. The token must at least have read-only access to public '
     + 'repositories.'
   ));
 

--- a/src/libs/config.ts
+++ b/src/libs/config.ts
@@ -1,4 +1,23 @@
-import { Config } from 'effect';
+import { Config, ConfigProvider, Effect, pipe } from 'effect';
+import envPaths from 'env-paths';
+import { readJsonFile } from './file.ts';
+
+const CONFIG_FILE_NAME = 'chtoolbox.json';
+
+const paths = envPaths('chtoolbox', { suffix: '' });
+
+const fileConfigProviderEffect = Effect.suspend(() => pipe(
+  readJsonFile(CONFIG_FILE_NAME, paths.config, {}),
+  Effect.map(ConfigProvider.fromJson),
+));
+
+export const configProviderEffect = Effect.suspend(() => pipe(
+  fileConfigProviderEffect,
+  Effect.map(fileConfigProvider => pipe(
+    ConfigProvider.fromEnv(),
+    ConfigProvider.orElse(() => fileConfigProvider)
+  )),
+));
 
 export const GITHUB_TOKEN = Config
   .redacted('GITHUB_TOKEN')

--- a/test/libs/config.spec.ts
+++ b/test/libs/config.spec.ts
@@ -1,23 +1,52 @@
 import { describe, it } from 'mocha';
-import { ConfigProvider, Effect, Either, Layer, Redacted } from 'effect';
+import { Config, ConfigProvider, Effect, Either, Layer, pipe, Redacted } from 'effect';
 import { expect } from 'chai';
-import { GITHUB_TOKEN } from '../../src/libs/config.ts';
-import { genWithLayer } from '../utils/base.ts';
+import * as ConfigLibs from '../../src/libs/config.ts';
+import { genWithLayer, sandbox } from '../utils/base.ts';
+import esmock from 'esmock';
+import { FileSystem } from '@effect/platform';
 
 const run = (config: [string, string][]) => genWithLayer(
   Layer.setConfigProvider(ConfigProvider.fromMap(new Map(config)))
 );
 
-describe('Config libs', () => {
-  it('returns redacted github token when provided', run(
-    [['GITHUB_TOKEN', 'ghp_example_token']]
-  )(function* () {
-    const token = yield* GITHUB_TOKEN;
-    expect(Redacted.value(token)).to.equal('ghp_example_token');
-  }));
+const readJsonFile = sandbox.stub();
 
-  it('fails when github token is missing', run([])(function* () {
-    const result = yield* Effect.either(GITHUB_TOKEN);
-    expect(Either.isLeft(result)).to.be.true;
-  }));
+const {
+  GITHUB_TOKEN,
+  configProviderEffect
+} = await esmock<typeof ConfigLibs>('../../src/libs/config.ts', {
+  '../../src/libs/file.ts': { readJsonFile }
+});
+
+describe('Config libs', () => {
+  it('configProviderEffect - loads config from JSON file', () => {
+    readJsonFile.returns(Effect.succeed({ CHTOOLBOX_TEST_VAL: 'hello world'}));
+
+    const configProvider = Effect.runSync(pipe(
+      configProviderEffect,
+      Effect.provide(Layer.succeed(FileSystem.FileSystem, {} as unknown as FileSystem.FileSystem))
+    ));
+
+    const result = Effect.runSync(pipe(
+      Config.string('CHTOOLBOX_TEST_VAL'),
+      Effect.withConfigProvider(configProvider)
+    ));
+
+    expect(result).to.equal('hello world');
+  });
+
+  describe('GITHUB_TOKEN', () => {
+    it('returns redacted github token when provided', run(
+      [['GITHUB_TOKEN', 'ghp_example_token']]
+    )(function* () {
+      const token = yield* GITHUB_TOKEN;
+      expect(Redacted.value(token)).to.equal('ghp_example_token');
+    }));
+
+    it('fails when github token is missing', run([])(function* () {
+      const result = yield* Effect.either(GITHUB_TOKEN);
+      expect(Either.isLeft(result)).to.be.true;
+    }));
+  });
 });


### PR DESCRIPTION
This PR adds support for loading config values from a `chtoolbox.json` file.  the file should be stored in a `chtoolbox` directory in the default config directory ([as defined by `env-path`](https://www.npmjs.com/package/env-paths#pathsconfig)).  So, `~/.config/chtoolbox/chtoolbox.json` on linux.
