### PR TITLE
feat: add support for `review` command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
 - Naming: files kebab-case; types PascalCase; variables camelCase; constants UPPER_SNAKE only if truly constant; test files mirror source name.
 - Prefer expressions over declarations (func-style=expression). Arrow functions where concise; keep arrow spacing.
 - Error handling: return Effect<E, A>; avoid throwing; convert external promise rejections into Effects; use typed errors or discriminated unions; never swallow errors.
+- Logging: non-debug/user-facing logging (e.g. Console.log) belongs only in src/commands files; libs/services stay side-effect-free and use Effect.logDebug for debug output.
 - Imports: group builtin/external/internal; no unused (eslint); avoid default export—prefer named.
 - Formatting enforced by eslint rules: 1TBS braces, unix linebreaks, consistent newline for arrays/functions, no nested ternaries, dot-notation, spacing rules (arrow, comma, keyword, key, semi, template-curly, rest-spread no space).
 - Testing: use chai + sinon + deep-equal-in-any-order + chai-exclude; reset sandbox afterEach (see test/utils/base.ts). Use Effect.runPromise for async.

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -42,7 +42,11 @@ export const review = Command
       targets => targets.length > 0,
       () => new Error('At least one --pr must be provided.'),
     ),
-    Effect.flatMap(targets => ReviewService.review(targets, { concurrency, timeout, outputDir })),
+    Effect.flatMap(targets => Effect.forEach(
+      targets,
+      target => ReviewService.review(target, { concurrency, timeout, outputDir }),
+      { concurrency: 1 },
+    )),
     Effect.tap(paths => Console.log(`\nWrote ${paths.length.toString()} report(s):\n${paths.join('\n')}`)),
   )))
   .pipe(Command.withDescription(

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -45,8 +45,14 @@ const outputDir = Options
     Options.withDefault('.'),
   );
 
-const reviewPr = (opts: ReviewOptions) => (target: PrTarget) => ReviewService.reviewPr(target, opts);
-const reviewCommit =  (opts: ReviewOptions) => (target: CommitTarget) => ReviewService.reviewCommit(target, opts);
+const reviewPr = (opts: ReviewOptions) => (target: PrTarget) => pipe(
+  Console.log(`Reviewing ${target.owner}/${target.repo}#${target.pullNumber.toString()}...`),
+  Effect.andThen(ReviewService.reviewPr(target, opts)),
+);
+const reviewCommit = (opts: ReviewOptions) => (target: CommitTarget) => pipe(
+  Console.log(`Reviewing ${target.owner}/${target.repo}@${target.sha}...`),
+  Effect.andThen(ReviewService.reviewCommit(target, opts)),
+);
 
 export const review = Command
   .make(

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,7 +1,7 @@
 import { Command, Options } from '@effect/cli';
-import { Console, Effect, pipe } from 'effect';
-import { ReviewService } from '../services/review.ts';
-import { parsePrTarget } from '../libs/review.ts';
+import { Console, Effect, pipe, Array } from 'effect';
+import { type ReviewOptions, ReviewService } from '../services/review.ts';
+import { type CommitTarget, parseCommitTarget, parsePrTarget, type PrTarget } from '../libs/review.ts';
 
 const pr = Options
   .text('pr')
@@ -10,6 +10,16 @@ const pr = Options
     Options.withDescription(
       'A GitHub PR to review, given as "org/repo#number" (e.g. medic/cht-core#11050) or a PR URL. Repeat the option '
       + 'to queue multiple PRs, which are reviewed in sequence.'
+    ),
+  );
+
+const commit = Options
+  .text('commit')
+  .pipe(
+    Options.repeated,
+    Options.withDescription(
+      'A GitHub commit to review against its parent, given as "org/repo#sha" (e.g. medic/cht-core#abc1234) or a '
+      + 'commit URL. Repeat the option to queue multiple commits, which are reviewed in sequence.'
     ),
   );
 
@@ -35,22 +45,34 @@ const outputDir = Options
     Options.withDefault('.'),
   );
 
+const reviewPr = (opts: ReviewOptions) => (target: PrTarget) => ReviewService.reviewPr(target, opts);
+const reviewCommit =  (opts: ReviewOptions) => (target: CommitTarget) => ReviewService.reviewCommit(target, opts);
+
 export const review = Command
-  .make('review', { pr, concurrency, timeout, outputDir }, Effect.fn(({ pr, concurrency, timeout, outputDir }) => pipe(
-    Effect.forEach(pr, parsePrTarget),
-    Effect.filterOrFail(
-      targets => targets.length > 0,
-      () => new Error('At least one --pr must be provided.'),
-    ),
-    Effect.flatMap(targets => Effect.forEach(
-      targets,
-      target => ReviewService.review(target, { concurrency, timeout, outputDir }),
-      { concurrency: 1 },
-    )),
-    Effect.tap(paths => Console.log(`\nWrote ${paths.length.toString()} report(s):\n${paths.join('\n')}`)),
-  )))
+  .make(
+    'review',
+    { pr, commit, concurrency, timeout, outputDir },
+    Effect.fn(({ pr, commit, concurrency, timeout, outputDir }) => pipe(
+      Effect.all({
+        prTargets: Effect.forEach(pr, parsePrTarget),
+        commitTargets: Effect.forEach(commit, parseCommitTarget),
+      }),
+      Effect.filterOrFail(
+        ({ prTargets, commitTargets }) => prTargets.length > 0 || commitTargets.length > 0,
+        () => new Error('At least one --pr or --commit must be provided.'),
+      ),
+      Effect.flatMap(({ prTargets, commitTargets }) => pipe(
+        [
+          ...Array.map(prTargets, reviewPr({ concurrency, timeout, outputDir })),
+          ...Array.map(commitTargets, reviewCommit({ concurrency, timeout, outputDir }))
+        ],
+        Effect.all,
+      )),
+      Effect.tap(paths => Console.log(`\nWrote ${paths.length.toString()} report(s):\n${paths.join('\n')}`)),
+    ))
+  )
   .pipe(Command.withDescription(
-    'Review one or more GitHub PRs with open-code-review (`ocr`). For each PR, checks out the PR branch range into a '
-    + 'temp directory, runs `ocr` against it, and writes a markdown report. Requires GITHUB_TOKEN and the `ocr` binary '
-    + 'on the PATH (with its own LLM configuration).'
+    'Review GitHub PRs and/or commits with open-code-review (`ocr`), writing one markdown report each. requires '
+    + 'GITHUB_TOKEN and the `ocr` binary on the PATH (with its own LLM configuration.  See '
+    + 'https://alibaba.github.io/open-code-review/ for more details on setting up ocr.'
   ));

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,0 +1,52 @@
+import { Command, Options } from '@effect/cli';
+import { Console, Effect, pipe } from 'effect';
+import { ReviewService } from '../services/review.ts';
+import { parsePrTarget } from '../libs/review.ts';
+
+const pr = Options
+  .text('pr')
+  .pipe(
+    Options.repeated,
+    Options.withDescription(
+      'A GitHub PR to review, given as "org/repo#number" (e.g. medic/cht-core#11050) or a PR URL. Repeat the option '
+      + 'to queue multiple PRs, which are reviewed in sequence.'
+    ),
+  );
+
+const concurrency = Options
+  .integer('concurrency')
+  .pipe(
+    Options.withDescription('Max concurrent file reviews passed through to `ocr`. Default is 1.'),
+    Options.withDefault(1),
+  );
+
+const timeout = Options
+  .integer('timeout')
+  .pipe(
+    Options.withDescription('Per-task timeout in minutes passed through to `ocr`. Default is 60.'),
+    Options.withDefault(60),
+  );
+
+const outputDir = Options
+  .directory('output-dir', { exists: 'either' })
+  .pipe(
+    Options.withAlias('o'),
+    Options.withDescription('Directory to write the markdown review reports into. Defaults to the current directory.'),
+    Options.withDefault('.'),
+  );
+
+export const review = Command
+  .make('review', { pr, concurrency, timeout, outputDir }, Effect.fn(({ pr, concurrency, timeout, outputDir }) => pipe(
+    Effect.forEach(pr, parsePrTarget),
+    Effect.filterOrFail(
+      targets => targets.length > 0,
+      () => new Error('At least one --pr must be provided.'),
+    ),
+    Effect.flatMap(targets => ReviewService.review(targets, { concurrency, timeout, outputDir })),
+    Effect.tap(paths => Console.log(`\nWrote ${paths.length.toString()} report(s):\n${paths.join('\n')}`)),
+  )))
+  .pipe(Command.withDescription(
+    'Review one or more GitHub PRs with open-code-review (`ocr`). For each PR, checks out the PR branch range into a '
+    + 'temp directory, runs `ocr` against it, and writes a markdown report. Requires GITHUB_TOKEN and the `ocr` binary '
+    + 'on the PATH (with its own LLM configuration).'
+  ));

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ import { localIp } from './commands/local-ip/index.ts';
 import { LocalIpService } from './services/local-ip.ts';
 import { SentinelBacklogService } from './services/sentinel-backlog.ts';
 import { sentinelBacklog } from './commands/sentinel-backlog/index.ts';
+import { ReviewService } from './services/review.ts';
+import { review } from './commands/review.ts';
 import { getChtxConfigProvider } from './libs/config.js';
 
 const withChtxConfigProvider = Effect.fn(<A, E, R>(
@@ -56,7 +58,8 @@ const SUBCOMMANDS = Array.make(
   subCommandWithConfig(db),
   subCommandWithConfig(upgrade),
   subCommandWithConfig(instance),
-  subCommandWithConfig(sentinelBacklog)
+  subCommandWithConfig(sentinelBacklog),
+  subCommandWithConfig(review)
 );
 
 const url = Options
@@ -99,6 +102,7 @@ pipe(
   Effect.provide(ReplicateService.Default),
   Effect.provide(SentinelBacklogService.Default),
   Effect.provide(TestDataGeneratorService.Default),
+  Effect.provide(ReviewService.Default),
   Effect.provide(PouchDBService.Default),
   Effect.provide(ChtClientService.Default.pipe(httpClientNoSslVerify)),
   Effect.provide(NodeContext.layer),

--- a/src/libs/github.ts
+++ b/src/libs/github.ts
@@ -8,6 +8,7 @@ import type { UnknownException } from 'effect/Cause';
 
 export type CompareCommitsData = RestEndpointMethodTypes['repos']['compareCommitsWithBasehead']['response']['data'];
 type RepoTagData = RestEndpointMethodTypes['repos']['listTags']['response']['data'];
+export type PullRequestData = RestEndpointMethodTypes['pulls']['get']['response']['data'];
 
 const octokitEffect = pipe(
   GITHUB_TOKEN,
@@ -108,6 +109,23 @@ export const compareRefs = (
   Effect.andThen(compareCommitsWithBasehead(owner, repo, baseRef, headRef)),
   Effect.map(reduceCompareCommitsData),
   Effect.flatMap(ensureAllChangedFilesIncluded(owner, repo)),
+));
+
+/**
+ * Fetches the metadata for a single pull request. The returned data includes the base ref (the branch the PR targets),
+ * the head ref, the PR title, and the html_url.
+ */
+export const getPullRequest = (
+  owner: string,
+  repo: string
+): (pullNumber: number) => Effect.Effect<PullRequestData, Error | ConfigError> => Effect.fn((pullNumber) => pipe(
+  octokitEffect,
+  Effect.flatMap(octokit => Effect.tryPromise(() => octokit.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  }))),
+  Effect.map(({ data }) => data),
 ));
 
 const getAllTags = Effect.fn((

--- a/src/libs/review.ts
+++ b/src/libs/review.ts
@@ -1,0 +1,143 @@
+import { Array, Effect, Option, pipe, Schema, String } from 'effect';
+import { type PullRequestData } from './github.js';
+import { mapErrorToGeneric } from './core.js';
+
+/**
+ * A GitHub pull request to review, parsed from the `org/repo#number` shorthand (or a full PR URL).
+ */
+export interface PrTarget {
+  readonly owner: string;
+  readonly repo: string;
+  readonly pullNumber: number;
+}
+
+const PR_SHORTHAND = /^([^/\s]+)\/([^/\s#]+)#(\d+)$/;
+const PR_URL = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)(?:[/?#].*)?$/;
+
+const toTarget = (match: RegExpMatchArray): PrTarget => ({
+  owner: globalThis.String(match[1]),
+  repo: globalThis.String(match[2]),
+  pullNumber: Number(match[3]),
+});
+
+/**
+ * Parses a value into a {@link PrTarget}. Accepts the `org/repo#number` shorthand (e.g. `medic/cht-core#11050`)
+ * or a full pull request URL (e.g. `https://github.com/medic/cht-core/pull/11050`).
+ */
+export const parsePrTarget = (raw: string): Effect.Effect<PrTarget, Error> => pipe(
+  String.trim(raw),
+  trimmed => Option.fromNullable(PR_SHORTHAND.exec(trimmed) ?? PR_URL.exec(trimmed)),
+  Option.map(toTarget),
+  Option.map(Effect.succeed),
+  Option.getOrElse(() => Effect.fail(new Error(
+    `Invalid --pr value: "${raw}". Expected "org/repo#number" (e.g. medic/cht-core#11050) or a pull request URL.`
+  ))),
+);
+
+/**
+ * A single review comment emitted by the `ocr` command in its JSON output.
+ */
+export class OcrComment extends Schema.Class<OcrComment>('OcrComment')({
+  path: Schema.optionalWith(Schema.String, { default: () => '' }),
+  start_line: Schema.optionalWith(Schema.Number, { default: () => 0 }),
+  end_line: Schema.optionalWith(Schema.Number, { default: () => 0 }),
+  content: Schema.optionalWith(Schema.String, { default: () => '' }),
+  existing_code: Schema.optional(Schema.String),
+  suggestion_code: Schema.optional(Schema.String),
+}) {}
+
+/**
+ * The top-level JSON document produced by `ocr review --format json`.
+ */
+export class OcrResult extends Schema.Class<OcrResult>('OcrResult')({
+  comments: Schema.optionalWith(Schema.Array(OcrComment), { default: () => [] }),
+  warnings: Schema.optionalWith(Schema.Array(Schema.String), { default: () => [] }),
+  message: Schema.optional(Schema.String),
+}) {}
+
+const decodeResult = Schema.decodeUnknown(Schema.parseJson(OcrResult));
+
+// `ocr` writes its JSON object to stdout; extract just the object so any stray output lines are ignored.
+const extractJson = (raw: string): string => pipe(
+  [raw.indexOf('{'), raw.lastIndexOf('}')] as const,
+  ([start, end]) => start >= 0 && end >= start
+    ? raw.slice(start, end + 1)
+    : '{}',
+);
+
+/**
+ * Parses the raw stdout from `ocr review --format json` into an {@link OcrResult}. Empty/whitespace output (or output
+ * with no JSON object) decodes to an empty result.
+ */
+export const decodeOcrResult = (raw: string): Effect.Effect<OcrResult, Error> => pipe(
+  extractJson(raw),
+  decodeResult,
+  mapErrorToGeneric,
+);
+
+const fence = (label: string, code: string): string => `**${label}:**\n\n\`\`\`\n${code}\n\`\`\`\n`;
+
+const commentLocation = ({ path, start_line, end_line }: OcrComment): string => {
+  if (start_line && end_line && start_line !== end_line) {
+    return `${path}:${start_line.toString()}-${end_line.toString()}`;
+  }
+  const line = end_line || start_line;
+  return line ? `${path}:${line.toString()}` : path;
+};
+
+const formatComment = (comment: OcrComment): string => pipe(
+  [
+    `### \`${commentLocation(comment)}\``,
+    comment.content,
+    comment.existing_code ? fence('Before', comment.existing_code) : '',
+    comment.suggestion_code ? fence('After', comment.suggestion_code) : '',
+  ],
+  Array.filter(String.isNonEmpty),
+  Array.join('\n\n'),
+);
+
+const commentsSection = (result: OcrResult): string => pipe(
+  result.comments,
+  Array.match({
+    onEmpty: () => result.message ?? 'No issues found.',
+    onNonEmpty: comments => pipe(comments, Array.map(formatComment), Array.join('\n\n---\n\n')),
+  }),
+);
+
+const warningsSection = (warnings: readonly string[]): string => pipe(
+  warnings,
+  Array.match({
+    onEmpty: () => '',
+    onNonEmpty: ws => pipe(
+      ws,
+      Array.map(w => `- ${w}`),
+      Array.join('\n'),
+      list => `\n\n## Warnings\n\n${list}`,
+    ),
+  }),
+);
+
+/**
+ * Compiles the `ocr` JSON result for a single PR into a readable markdown document.
+ */
+export const formatReport = (
+  target: PrTarget,
+  prData: Pick<PullRequestData, 'title' | 'html_url' | 'base' | 'head'>,
+  result: OcrResult,
+): string => pipe(
+  [
+    `# ${target.owner}/${target.repo}#${target.pullNumber.toString()}: ${prData.title}`,
+    prData.html_url,
+    `Reviewed \`${prData.base.ref}...${prData.head.ref}\` with open-code-review.`,
+    `## Findings`,
+    commentsSection(result),
+  ],
+  Array.join('\n\n'),
+  report => `${report}${warningsSection(result.warnings)}\n`,
+);
+
+/**
+ * The markdown filename for a PR's review report, e.g. `medic-cht-core-pr11050.md`.
+ */
+export const reportFileName = ({ owner, repo, pullNumber }: PrTarget): string =>
+  `${owner}-${repo}-pr${pullNumber.toString()}.md`;

--- a/src/libs/review.ts
+++ b/src/libs/review.ts
@@ -37,7 +37,7 @@ export const parsePrTarget = (raw: string): Effect.Effect<PrTarget, Error> => pi
 /**
  * A single review comment emitted by the `ocr` command in its JSON output.
  */
-export class OcrComment extends Schema.Class<OcrComment>('OcrComment')({
+class OcrComment extends Schema.Class<OcrComment>('OcrComment')({
   path: Schema.optionalWith(Schema.String, { default: () => '' }),
   start_line: Schema.optionalWith(Schema.Number, { default: () => 0 }),
   end_line: Schema.optionalWith(Schema.Number, { default: () => 0 }),
@@ -49,7 +49,7 @@ export class OcrComment extends Schema.Class<OcrComment>('OcrComment')({
 /**
  * The top-level JSON document produced by `ocr review --format json`.
  */
-export class OcrResult extends Schema.Class<OcrResult>('OcrResult')({
+class OcrResult extends Schema.Class<OcrResult>('OcrResult')({
   comments: Schema.optionalWith(Schema.Array(OcrComment), { default: () => [] }),
   warnings: Schema.optionalWith(Schema.Array(Schema.String), { default: () => [] }),
   message: Schema.optional(Schema.String),

--- a/src/libs/review.ts
+++ b/src/libs/review.ts
@@ -11,13 +11,31 @@ export interface PrTarget {
   readonly pullNumber: number;
 }
 
+/**
+ * A GitHub commit to review, parsed from the `org/repo#sha` shorthand (or a full commit URL).
+ */
+export interface CommitTarget {
+  readonly owner: string;
+  readonly repo: string;
+  readonly sha: string;
+}
+
 const PR_SHORTHAND = /^([^/\s]+)\/([^/\s#]+)#(\d+)$/;
 const PR_URL = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/pull\/(\d+)(?:[/?#].*)?$/;
 
-const toTarget = (match: RegExpMatchArray): PrTarget => ({
+const COMMIT_SHORTHAND = /^([^/\s]+)\/([^/\s#]+)#([^/\s#]+)$/;
+const COMMIT_URL = /^https?:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/commit\/([^/\s#]+)(?:[/?#].*)?$/;
+
+const toPrTarget = (match: RegExpMatchArray): PrTarget => ({
   owner: globalThis.String(match[1]),
   repo: globalThis.String(match[2]),
   pullNumber: Number(match[3]),
+});
+
+const toCommitTarget = (match: RegExpMatchArray): CommitTarget => ({
+  owner: globalThis.String(match[1]),
+  repo: globalThis.String(match[2]),
+  sha: globalThis.String(match[3]),
 });
 
 /**
@@ -27,10 +45,24 @@ const toTarget = (match: RegExpMatchArray): PrTarget => ({
 export const parsePrTarget = (raw: string): Effect.Effect<PrTarget, Error> => pipe(
   String.trim(raw),
   trimmed => Option.fromNullable(PR_SHORTHAND.exec(trimmed) ?? PR_URL.exec(trimmed)),
-  Option.map(toTarget),
+  Option.map(toPrTarget),
   Option.map(Effect.succeed),
   Option.getOrElse(() => Effect.fail(new Error(
     `Invalid --pr value: "${raw}". Expected "org/repo#number" (e.g. medic/cht-core#11050) or a pull request URL.`
+  ))),
+);
+
+/**
+ * Parses a value into a {@link CommitTarget}. Accepts the `org/repo#sha` shorthand (e.g. `medic/cht-core#abc1234`)
+ * or a full commit URL (e.g. `https://github.com/medic/cht-core/commit/abc1234`).
+ */
+export const parseCommitTarget = (raw: string): Effect.Effect<CommitTarget, Error> => pipe(
+  String.trim(raw),
+  trimmed => Option.fromNullable(COMMIT_SHORTHAND.exec(trimmed) ?? COMMIT_URL.exec(trimmed)),
+  Option.map(toCommitTarget),
+  Option.map(Effect.succeed),
+  Option.getOrElse(() => Effect.fail(new Error(
+    `Invalid --commit value: "${raw}". Expected "org/repo#sha" (e.g. medic/cht-core#abc1234) or a commit URL.`
   ))),
 );
 
@@ -117,6 +149,12 @@ const warningsSection = (warnings: readonly string[]): string => pipe(
   }),
 );
 
+const reportBody = (header: readonly string[], result: OcrResult): string => pipe(
+  [...header, `## Findings`, commentsSection(result)],
+  Array.join('\n\n'),
+  report => `${report}${warningsSection(result.warnings)}\n`,
+);
+
 /**
  * Compiles the `ocr` JSON result for a single PR into a readable markdown document.
  */
@@ -124,20 +162,30 @@ export const formatReport = (
   target: PrTarget,
   prData: Pick<PullRequestData, 'title' | 'html_url' | 'base' | 'head'>,
   result: OcrResult,
-): string => pipe(
-  [
-    `# ${target.owner}/${target.repo}#${target.pullNumber.toString()}: ${prData.title}`,
-    prData.html_url,
-    `Reviewed \`${prData.base.ref}...${prData.head.ref}\` with open-code-review.`,
-    `## Findings`,
-    commentsSection(result),
-  ],
-  Array.join('\n\n'),
-  report => `${report}${warningsSection(result.warnings)}\n`,
-);
+): string => reportBody([
+  `# ${target.owner}/${target.repo}#${target.pullNumber.toString()}: ${prData.title}`,
+  prData.html_url,
+  `Reviewed \`${prData.base.ref}...${prData.head.ref}\` with open-code-review.`,
+], result);
+
+/**
+ * Compiles the `ocr` JSON result for a single commit into a readable markdown document.
+ */
+export const formatCommitReport = (target: CommitTarget, result: OcrResult): string => reportBody([
+  `# ${target.owner}/${target.repo}@${target.sha}`,
+  `https://github.com/${target.owner}/${target.repo}/commit/${target.sha}`,
+  `Reviewed commit \`${target.sha}\` with open-code-review.`,
+], result);
 
 /**
  * The markdown filename for a PR's review report, e.g. `medic-cht-core-pr11050.md`.
  */
 export const reportFileName = ({ owner, repo, pullNumber }: PrTarget): string =>
   `${owner}-${repo}-pr${pullNumber.toString()}.md`;
+
+/**
+ * The markdown filename for a commit's review report, e.g. `medic-cht-core-commit-abc1234.md`. Characters in the sha
+ * that are not path-safe are replaced with dashes.
+ */
+export const commitReportFileName = ({ owner, repo, sha }: CommitTarget): string =>
+  `${owner}-${repo}-commit-${sha.replace(/[^\w.-]/g, '-')}.md`;

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -1,0 +1,122 @@
+import { Console, Effect, pipe, Redacted } from 'effect';
+import * as Context from 'effect/Context';
+import { Command, FileSystem } from '@effect/platform';
+import { CommandExecutor } from '@effect/platform/CommandExecutor';
+import { join } from 'node:path';
+import { getPullRequest } from '../libs/github.js';
+import { GITHUB_TOKEN } from '../libs/config.js';
+import { createDir, createTmpDir, writeFile } from '../libs/file.js';
+import { decodeOcrResult, formatReport, type PrTarget, reportFileName } from '../libs/review.js';
+import { mapErrorToGeneric } from '../libs/core.js';
+
+export interface ReviewOptions {
+  readonly concurrency: number;
+  readonly timeout: number;
+  readonly outputDir: string;
+}
+
+const remoteUrl = (token: string, owner: string, repo: string): string =>
+  `https://x-access-token:${token}@github.com/${owner}/${repo}.git`;
+
+const runGit = (tmpDir: string, label: string, args: string[]) => Command
+  .make('git', ...args)
+  .pipe(
+    Command.workingDirectory(tmpDir),
+    Command.exitCode,
+    Effect.filterOrFail(
+      exitCode => exitCode === 0,
+      exitCode => new Error(`git ${label} failed (exit code ${exitCode.toString()})`)
+    ),
+  );
+
+// Initialize a throwaway repo in `tmpDir` and fetch both the PR base branch (as `ocr-base`) and the PR head (as
+// `ocr-head`). The base repo's `pull/<n>/head` ref resolves fork PRs too, so a single remote is enough.
+const checkoutPr = (target: PrTarget, baseRef: string, tmpDir: string) => pipe(
+  GITHUB_TOKEN,
+  Effect.map(Redacted.value),
+  Effect.flatMap(token => pipe(
+    runGit(tmpDir, 'init', ['init', '-q']),
+    Effect.andThen(runGit(
+      tmpDir,
+      'remote add',
+      ['remote', 'add', 'origin', remoteUrl(token, target.owner, target.repo)]
+    )),
+    Effect.andThen(runGit(
+      tmpDir,
+      'fetch',
+      ['fetch', '--no-tags', 'origin', `${baseRef}:ocr-base`, `pull/${target.pullNumber.toString()}/head:ocr-head`]
+    )),
+  )),
+);
+
+const runOcr = (tmpDir: string, { concurrency, timeout }: ReviewOptions) => Command
+  .make(
+    'ocr',
+    'review',
+    '--repo',
+    tmpDir,
+    '--from',
+    'ocr-base',
+    '--to',
+    'ocr-head',
+    '--format',
+    'json',
+    '--audience',
+    'agent',
+    '--concurrency',
+    concurrency.toString(),
+    '--timeout',
+    timeout.toString(),
+  )
+  .pipe(
+    Command.stderr('inherit'),
+    Command.string,
+  );
+
+const writeReport = (outputDir: string, target: PrTarget, report: string) => pipe(
+  createDir(outputDir),
+  Effect.andThen(join(outputDir, reportFileName(target))),
+  Effect.tap(path => writeFile(path)(report)),
+);
+
+const reviewPr = (target: PrTarget, options: ReviewOptions) => pipe(
+  Console.log(`Reviewing ${target.owner}/${target.repo}#${target.pullNumber.toString()}...`),
+  Effect.andThen(getPullRequest(target.owner, target.repo)(target.pullNumber)),
+  Effect.flatMap(prData => pipe(
+    createTmpDir(),
+    Effect.tap(tmpDir => checkoutPr(target, prData.base.ref, tmpDir)),
+    Effect.flatMap(tmpDir => runOcr(tmpDir, options)),
+    Effect.flatMap(decodeOcrResult),
+    Effect.map(result => formatReport(target, prData, result)),
+    Effect.flatMap(report => writeReport(options.outputDir, target, report)),
+  )),
+  Effect.scoped,
+);
+
+const serviceContext = Effect
+  .all([
+    FileSystem.FileSystem,
+    CommandExecutor,
+  ])
+  .pipe(Effect.map(([
+    fileSystem,
+    executor,
+  ]) => Context
+    .make(FileSystem.FileSystem, fileSystem)
+    .pipe(Context.add(CommandExecutor, executor))));
+
+export class ReviewService extends Effect.Service<ReviewService>()('chtoolbox/ReviewService', {
+  effect: serviceContext.pipe(Effect.map(context => ({
+    // Reviews each PR in sequence, writing one markdown report per PR. Returns the written file paths.
+    review: Effect.fn((
+      targets: PrTarget[],
+      options: ReviewOptions
+    ): Effect.Effect<string[], Error> => pipe(
+      Effect.forEach(targets, target => reviewPr(target, options), { concurrency: 1 }),
+      Effect.provide(context),
+      mapErrorToGeneric,
+    )),
+  }))),
+  accessors: true,
+}) {
+}

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -9,7 +9,7 @@ import { createDir, createTmpDir, writeFile } from '../libs/file.js';
 import { decodeOcrResult, formatReport, type PrTarget, reportFileName } from '../libs/review.js';
 import { mapErrorToGeneric } from '../libs/core.js';
 
-export interface ReviewOptions {
+interface ReviewOptions {
   readonly concurrency: number;
   readonly timeout: number;
   readonly outputDir: string;
@@ -107,12 +107,11 @@ const serviceContext = Effect
 
 export class ReviewService extends Effect.Service<ReviewService>()('chtoolbox/ReviewService', {
   effect: serviceContext.pipe(Effect.map(context => ({
-    // Reviews each PR in sequence, writing one markdown report per PR. Returns the written file paths.
     review: Effect.fn((
-      targets: PrTarget[],
+      target: PrTarget,
       options: ReviewOptions
-    ): Effect.Effect<string[], Error> => pipe(
-      Effect.forEach(targets, target => reviewPr(target, options), { concurrency: 1 }),
+    ): Effect.Effect<string, Error> => pipe(
+      reviewPr(target, options),
       Effect.provide(context),
       mapErrorToGeneric,
     )),

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -1,4 +1,4 @@
-import { Console, Effect, pipe, Redacted } from 'effect';
+import { Effect, pipe, Redacted } from 'effect';
 import * as Context from 'effect/Context';
 import { Command, FileSystem } from '@effect/platform';
 import { CommandExecutor } from '@effect/platform/CommandExecutor';
@@ -93,8 +93,7 @@ const writeReport = (outputDir: string, fileName: string, report: string) => pip
 );
 
 const runPrReview = (target: PrTarget, options: ReviewOptions) => pipe(
-  Console.log(`Reviewing ${target.owner}/${target.repo}#${target.pullNumber.toString()}...`),
-  Effect.andThen(getPullRequest(target.owner, target.repo)(target.pullNumber)),
+  getPullRequest(target.owner, target.repo)(target.pullNumber),
   Effect.flatMap(prData => pipe(
     createTmpDir(),
     Effect.tap(tmpDir => checkoutPr(target, prData.base.ref, tmpDir)),
@@ -108,8 +107,7 @@ const runPrReview = (target: PrTarget, options: ReviewOptions) => pipe(
 
 // Reviews a single commit by cloning its repo into a temp dir and running ocr's `--commit` mode against it.
 const runCommitReview = (target: CommitTarget, options: ReviewOptions) => pipe(
-  Console.log(`Reviewing ${target.owner}/${target.repo}@${target.sha}...`),
-  Effect.andThen(createTmpDir()),
+  createTmpDir(),
   Effect.tap(tmpDir => checkoutCommit(target, tmpDir)),
   Effect.flatMap(tmpDir => runOcr(['--repo', tmpDir, '--commit', target.sha], options)),
   Effect.flatMap(decodeOcrResult),

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -92,11 +92,22 @@ const writeReport = (outputDir: string, fileName: string, report: string) => pip
   Effect.tap(path => writeFile(path)(report)),
 );
 
+const OCR_RULE = JSON.stringify({
+  rules: [],
+  include: ['**/*.spec.{js,jsx,ts,tsx}'],
+}, null, 2);
+
+const writeOcrRule = (tmpDir: string) => pipe(
+  createDir(join(tmpDir, '.opencodereview')),
+  Effect.andThen(writeFile(join(tmpDir, '.opencodereview', 'rule.json'))(OCR_RULE)),
+);
+
 const runPrReview = (target: PrTarget, options: ReviewOptions) => pipe(
   getPullRequest(target.owner, target.repo)(target.pullNumber),
   Effect.flatMap(prData => pipe(
     createTmpDir(),
     Effect.tap(tmpDir => checkoutPr(target, prData.base.ref, tmpDir)),
+    Effect.tap(writeOcrRule),
     Effect.flatMap(tmpDir => runOcr(['--repo', tmpDir, '--from', 'ocr-base', '--to', 'ocr-head'], options)),
     Effect.flatMap(decodeOcrResult),
     Effect.map(result => formatReport(target, prData, result)),
@@ -109,6 +120,7 @@ const runPrReview = (target: PrTarget, options: ReviewOptions) => pipe(
 const runCommitReview = (target: CommitTarget, options: ReviewOptions) => pipe(
   createTmpDir(),
   Effect.tap(tmpDir => checkoutCommit(target, tmpDir)),
+  Effect.tap(writeOcrRule),
   Effect.flatMap(tmpDir => runOcr(['--repo', tmpDir, '--commit', target.sha], options)),
   Effect.flatMap(decodeOcrResult),
   Effect.map(result => formatCommitReport(target, result)),

--- a/src/services/review.ts
+++ b/src/services/review.ts
@@ -6,10 +6,18 @@ import { join } from 'node:path';
 import { getPullRequest } from '../libs/github.js';
 import { GITHUB_TOKEN } from '../libs/config.js';
 import { createDir, createTmpDir, writeFile } from '../libs/file.js';
-import { decodeOcrResult, formatReport, type PrTarget, reportFileName } from '../libs/review.js';
+import {
+  type CommitTarget,
+  commitReportFileName,
+  decodeOcrResult,
+  formatCommitReport,
+  formatReport,
+  type PrTarget,
+  reportFileName,
+} from '../libs/review.js';
 import { mapErrorToGeneric } from '../libs/core.js';
 
-interface ReviewOptions {
+export interface ReviewOptions {
   readonly concurrency: number;
   readonly timeout: number;
   readonly outputDir: string;
@@ -29,36 +37,41 @@ const runGit = (tmpDir: string, label: string, args: string[]) => Command
     ),
   );
 
-// Initialize a throwaway repo in `tmpDir` and fetch both the PR base branch (as `ocr-base`) and the PR head (as
-// `ocr-head`). The base repo's `pull/<n>/head` ref resolves fork PRs too, so a single remote is enough.
-const checkoutPr = (target: PrTarget, baseRef: string, tmpDir: string) => pipe(
+// Initialize a throwaway repo in `tmpDir`, point it at the given GitHub repo, and fetch the requested refspecs.
+const initAndFetch = (owner: string, repo: string, tmpDir: string, fetchArgs: string[]) => pipe(
   GITHUB_TOKEN,
   Effect.map(Redacted.value),
   Effect.flatMap(token => pipe(
     runGit(tmpDir, 'init', ['init', '-q']),
-    Effect.andThen(runGit(
-      tmpDir,
-      'remote add',
-      ['remote', 'add', 'origin', remoteUrl(token, target.owner, target.repo)]
-    )),
-    Effect.andThen(runGit(
-      tmpDir,
-      'fetch',
-      ['fetch', '--no-tags', 'origin', `${baseRef}:ocr-base`, `pull/${target.pullNumber.toString()}/head:ocr-head`]
-    )),
+    Effect.andThen(runGit(tmpDir, 'remote add', ['remote', 'add', 'origin', remoteUrl(token, owner, repo)])),
+    Effect.andThen(runGit(tmpDir, 'fetch', ['fetch', '--no-tags', 'origin', ...fetchArgs])),
   )),
 );
 
-const runOcr = (tmpDir: string, { concurrency, timeout }: ReviewOptions) => Command
+// Fetch the PR base branch (as `ocr-base`) and the PR head (as `ocr-head`). The base repo's `pull/<n>/head` ref
+// resolves fork PRs too, so a single remote is enough.
+const checkoutPr = (target: PrTarget, baseRef: string, tmpDir: string) => initAndFetch(
+  target.owner,
+  target.repo,
+  tmpDir,
+  [`${baseRef}:ocr-base`, `pull/${target.pullNumber.toString()}/head:ocr-head`],
+);
+
+// Fetch the commit (and its ancestry, so `ocr` can diff it against its parent) into the throwaway repo.
+const checkoutCommit = (target: CommitTarget, tmpDir: string) => initAndFetch(
+  target.owner,
+  target.repo,
+  tmpDir,
+  [target.sha],
+);
+
+// Builds an `ocr review` command with the shared output flags. `rangeArgs` selects what to review (a from/to range
+// against a temp checkout, or a single commit against the current repo).
+const runOcr = (rangeArgs: string[], { concurrency, timeout }: ReviewOptions) => Command
   .make(
     'ocr',
     'review',
-    '--repo',
-    tmpDir,
-    '--from',
-    'ocr-base',
-    '--to',
-    'ocr-head',
+    ...rangeArgs,
     '--format',
     'json',
     '--audience',
@@ -73,23 +86,35 @@ const runOcr = (tmpDir: string, { concurrency, timeout }: ReviewOptions) => Comm
     Command.string,
   );
 
-const writeReport = (outputDir: string, target: PrTarget, report: string) => pipe(
+const writeReport = (outputDir: string, fileName: string, report: string) => pipe(
   createDir(outputDir),
-  Effect.andThen(join(outputDir, reportFileName(target))),
+  Effect.andThen(join(outputDir, fileName)),
   Effect.tap(path => writeFile(path)(report)),
 );
 
-const reviewPr = (target: PrTarget, options: ReviewOptions) => pipe(
+const runPrReview = (target: PrTarget, options: ReviewOptions) => pipe(
   Console.log(`Reviewing ${target.owner}/${target.repo}#${target.pullNumber.toString()}...`),
   Effect.andThen(getPullRequest(target.owner, target.repo)(target.pullNumber)),
   Effect.flatMap(prData => pipe(
     createTmpDir(),
     Effect.tap(tmpDir => checkoutPr(target, prData.base.ref, tmpDir)),
-    Effect.flatMap(tmpDir => runOcr(tmpDir, options)),
+    Effect.flatMap(tmpDir => runOcr(['--repo', tmpDir, '--from', 'ocr-base', '--to', 'ocr-head'], options)),
     Effect.flatMap(decodeOcrResult),
     Effect.map(result => formatReport(target, prData, result)),
-    Effect.flatMap(report => writeReport(options.outputDir, target, report)),
+    Effect.flatMap(report => writeReport(options.outputDir, reportFileName(target), report)),
   )),
+  Effect.scoped,
+);
+
+// Reviews a single commit by cloning its repo into a temp dir and running ocr's `--commit` mode against it.
+const runCommitReview = (target: CommitTarget, options: ReviewOptions) => pipe(
+  Console.log(`Reviewing ${target.owner}/${target.repo}@${target.sha}...`),
+  Effect.andThen(createTmpDir()),
+  Effect.tap(tmpDir => checkoutCommit(target, tmpDir)),
+  Effect.flatMap(tmpDir => runOcr(['--repo', tmpDir, '--commit', target.sha], options)),
+  Effect.flatMap(decodeOcrResult),
+  Effect.map(result => formatCommitReport(target, result)),
+  Effect.flatMap(report => writeReport(options.outputDir, commitReportFileName(target), report)),
   Effect.scoped,
 );
 
@@ -107,11 +132,21 @@ const serviceContext = Effect
 
 export class ReviewService extends Effect.Service<ReviewService>()('chtoolbox/ReviewService', {
   effect: serviceContext.pipe(Effect.map(context => ({
-    review: Effect.fn((
+    // Reviews a single PR (checking out its branch range into a temp dir). Returns the written report path.
+    reviewPr: Effect.fn((
       target: PrTarget,
       options: ReviewOptions
     ): Effect.Effect<string, Error> => pipe(
-      reviewPr(target, options),
+      runPrReview(target, options),
+      Effect.provide(context),
+      mapErrorToGeneric,
+    )),
+    // Reviews a single commit (cloning its repo into a temp dir). Returns the written report path.
+    reviewCommit: Effect.fn((
+      target: CommitTarget,
+      options: ReviewOptions
+    ): Effect.Effect<string, Error> => pipe(
+      runCommitReview(target, options),
       Effect.provide(context),
       mapErrorToGeneric,
     )),

--- a/test/libs/github.spec.ts
+++ b/test/libs/github.spec.ts
@@ -13,7 +13,7 @@ const base = 'base';
 const head = 'head';
 
 const octokit = sandbox.stub();
-const { compareRefs, getReleaseNames } = await esmock<typeof GitHubLibs>('../../src/libs/github.ts', {
+const { compareRefs, getReleaseNames, getPullRequest } = await esmock<typeof GitHubLibs>('../../src/libs/github.ts', {
   '../../src/libs/shim.ts': { octokit },
 });
 
@@ -29,22 +29,40 @@ describe('GitHub libs', () => {
   let compareCommitsWithBasehead: SinonStub;
   let listTags: SinonStub;
   let listCommits: SinonStub;
+  let pullsGet: SinonStub;
 
   beforeEach(() => {
     paginate = sinon.stub();
     compareCommitsWithBasehead = sinon.stub();
     listTags = sinon.stub();
     listCommits = sinon.stub();
+    pullsGet = sinon.stub();
     octokit.returns({
       paginate,
-      rest: { 
-        repos: { 
+      rest: {
+        repos: {
           compareCommitsWithBasehead,
           listTags,
-          listCommits 
-        } 
+          listCommits
+        },
+        pulls: {
+          get: pullsGet
+        }
       }
     });
+  });
+
+  describe('getPullRequest', () => {
+    it('returns the pull request metadata', run(function* () {
+      const data = { title: 'A PR', html_url: 'url', base: { ref: 'master' }, head: { ref: 'feature' } };
+      pullsGet.resolves({ data });
+
+      const result = yield* getPullRequest(owner, repo)(11050);
+
+      expect(result).to.deep.equal(data);
+      expect(octokit).calledOnceWithExactly({ auth: GITHUB_TOKEN });
+      expect(pullsGet).calledOnceWithExactly({ owner, repo, pull_number: 11050 });
+    }));
   });
 
   describe('compareRefs', () => {

--- a/test/libs/review.spec.ts
+++ b/test/libs/review.spec.ts
@@ -1,0 +1,168 @@
+import { describe, it } from 'mocha';
+import { Effect, Either } from 'effect';
+import { expect } from 'chai';
+import {
+  decodeOcrResult,
+  formatReport,
+  parsePrTarget,
+  type PrTarget,
+  reportFileName,
+} from '../../src/libs/review.ts';
+
+const run = (test: Effect.Effect<void, Error>) => (): Promise<void> => Effect.runPromise(test);
+
+const TARGET: PrTarget = { owner: 'medic', repo: 'cht-core', pullNumber: 11050 };
+
+const PR_DATA = {
+  title: 'Fix the thing',
+  html_url: 'https://github.com/medic/cht-core/pull/11050',
+  base: { ref: 'master' },
+  head: { ref: 'fix/the-thing' },
+} as Parameters<typeof formatReport>[1];
+
+describe('Review libs', () => {
+  describe('parsePrTarget', () => {
+    it('parses org/repo#number shorthand', run(Effect.gen(function* () {
+      const target = yield* parsePrTarget('medic/cht-core#11050');
+      expect(target).to.deep.equal(TARGET);
+    })));
+
+    it('trims surrounding whitespace', run(Effect.gen(function* () {
+      const target = yield* parsePrTarget('  medic/cht-core#11050  ');
+      expect(target).to.deep.equal(TARGET);
+    })));
+
+    it('parses a full PR URL', run(Effect.gen(function* () {
+      const target = yield* parsePrTarget('https://github.com/medic/cht-core/pull/11050');
+      expect(target).to.deep.equal(TARGET);
+    })));
+
+    it('parses a PR URL with a trailing path', run(Effect.gen(function* () {
+      const target = yield* parsePrTarget('https://github.com/medic/cht-core/pull/11050/files');
+      expect(target).to.deep.equal(TARGET);
+    })));
+
+    [
+      'not-a-pr',
+      'medic/cht-core',
+      'medic/cht-core#',
+      'medic/cht-core#abc',
+      'https://github.com/medic/cht-core/issues/11050',
+    ].forEach(raw => it(`fails on invalid value: ${raw}`, run(Effect.gen(function* () {
+      const either = yield* parsePrTarget(raw).pipe(Effect.either);
+      if (Either.isRight(either)) {
+        expect.fail('Expected a parse error');
+      }
+      expect(either.left).to.be.instanceOf(Error);
+      expect(either.left.message).to.contain(raw);
+    }))));
+  });
+
+  describe('decodeOcrResult', () => {
+    it('decodes findings', run(Effect.gen(function* () {
+      const raw = JSON.stringify({
+        comments: [{ path: 'a.ts', start_line: 1, end_line: 2, content: 'oops' }],
+        warnings: ['heads up'],
+      });
+      const result = yield* decodeOcrResult(raw);
+      expect(result.comments).to.have.length(1);
+      expect(result.comments[0]).to.include({ path: 'a.ts', start_line: 1, end_line: 2, content: 'oops' });
+      expect(result.warnings).to.deep.equal(['heads up']);
+    })));
+
+    it('decodes a clean message result', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult(JSON.stringify({ message: 'Looks good to me.' }));
+      expect(result.comments).to.be.empty;
+      expect(result.message).to.equal('Looks good to me.');
+    })));
+
+    it('ignores stray output around the JSON object', run(Effect.gen(function* () {
+      const raw = `some log line\n${JSON.stringify({ message: 'ok' })}\ntrailing`;
+      const result = yield* decodeOcrResult(raw);
+      expect(result.message).to.equal('ok');
+    })));
+
+    it('treats empty output as an empty result', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult('   ');
+      expect(result.comments).to.be.empty;
+      expect(result.warnings).to.be.empty;
+    })));
+
+    it('fails on malformed JSON', run(Effect.gen(function* () {
+      const either = yield* decodeOcrResult('{ "comments": [ }').pipe(Effect.either);
+      if (Either.isRight(either)) {
+        expect.fail('Expected a decode error');
+      }
+      expect(either.left).to.be.instanceOf(Error);
+    })));
+  });
+
+  describe('formatReport', () => {
+    it('renders findings with before/after code blocks', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult(JSON.stringify({
+        comments: [
+          {
+            path: 'src/a.ts',
+            start_line: 10,
+            end_line: 12,
+            content: 'Possible null deref',
+            existing_code: 'foo.bar',
+            suggestion_code: 'foo?.bar',
+          },
+        ],
+        warnings: ['truncated diff'],
+      }));
+
+      const report = formatReport(TARGET, PR_DATA, result);
+
+      expect(report).to.contain('# medic/cht-core#11050: Fix the thing');
+      expect(report).to.contain('https://github.com/medic/cht-core/pull/11050');
+      expect(report).to.contain('`master...fix/the-thing`');
+      expect(report).to.contain('### `src/a.ts:10-12`');
+      expect(report).to.contain('Possible null deref');
+      expect(report).to.contain('**Before:**');
+      expect(report).to.contain('foo.bar');
+      expect(report).to.contain('**After:**');
+      expect(report).to.contain('foo?.bar');
+      expect(report).to.contain('## Warnings');
+      expect(report).to.contain('- truncated diff');
+    })));
+
+    it('renders the clean message and omits the warnings section', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult(JSON.stringify({ message: 'No comments generated.' }));
+      const report = formatReport(TARGET, PR_DATA, result);
+      expect(report).to.contain('No comments generated.');
+      expect(report).to.not.contain('## Warnings');
+    })));
+
+    it('falls back to "No issues found." when there are no comments and no message', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult(JSON.stringify({ comments: [] }));
+      const report = formatReport(TARGET, PR_DATA, result);
+      expect(report).to.contain('No issues found.');
+    })));
+
+    it('renders comments with partial/missing line info and applies field defaults', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult(JSON.stringify({
+        comments: [
+          {},                                                  // all fields default (path '', lines 0, content '')
+          { path: 'b.ts', end_line: 5, content: 'only end' },  // single line
+          { path: 'c.ts', start_line: 7, end_line: 7, content: 'same line' },
+        ],
+      }));
+
+      // defaults applied during decode
+      expect(result.comments[0]).to.include({ path: '', start_line: 0, end_line: 0, content: '' });
+
+      const report = formatReport(TARGET, PR_DATA, result);
+      expect(report).to.contain('### ``');        // empty path/no line → just the (empty) path
+      expect(report).to.contain('### `b.ts:5`');   // single line via end_line
+      expect(report).to.contain('### `c.ts:7`');   // start_line === end_line collapses to one line
+    })));
+  });
+
+  describe('reportFileName', () => {
+    it('builds a per-PR filename', () => {
+      expect(reportFileName(TARGET)).to.equal('medic-cht-core-pr11050.md');
+    });
+  });
+});

--- a/test/libs/review.spec.ts
+++ b/test/libs/review.spec.ts
@@ -2,8 +2,12 @@ import { describe, it } from 'mocha';
 import { Effect, Either } from 'effect';
 import { expect } from 'chai';
 import {
+  type CommitTarget,
+  commitReportFileName,
   decodeOcrResult,
+  formatCommitReport,
   formatReport,
+  parseCommitTarget,
   parsePrTarget,
   type PrTarget,
   reportFileName,
@@ -12,6 +16,7 @@ import {
 const run = (test: Effect.Effect<void, Error>) => (): Promise<void> => Effect.runPromise(test);
 
 const TARGET: PrTarget = { owner: 'medic', repo: 'cht-core', pullNumber: 11050 };
+const COMMIT_TARGET: CommitTarget = { owner: 'medic', repo: 'cht-core', sha: 'abc1234' };
 
 const PR_DATA = {
   title: 'Fix the thing',
@@ -50,6 +55,42 @@ describe('Review libs', () => {
       'https://github.com/medic/cht-core/issues/11050',
     ].forEach(raw => it(`fails on invalid value: ${raw}`, run(Effect.gen(function* () {
       const either = yield* parsePrTarget(raw).pipe(Effect.either);
+      if (Either.isRight(either)) {
+        expect.fail('Expected a parse error');
+      }
+      expect(either.left).to.be.instanceOf(Error);
+      expect(either.left.message).to.contain(raw);
+    }))));
+  });
+
+  describe('parseCommitTarget', () => {
+    it('parses org/repo#sha shorthand', run(Effect.gen(function* () {
+      const target = yield* parseCommitTarget('medic/cht-core#abc1234');
+      expect(target).to.deep.equal(COMMIT_TARGET);
+    })));
+
+    it('trims surrounding whitespace', run(Effect.gen(function* () {
+      const target = yield* parseCommitTarget('  medic/cht-core#abc1234  ');
+      expect(target).to.deep.equal(COMMIT_TARGET);
+    })));
+
+    it('parses a full commit URL', run(Effect.gen(function* () {
+      const target = yield* parseCommitTarget('https://github.com/medic/cht-core/commit/abc1234');
+      expect(target).to.deep.equal(COMMIT_TARGET);
+    })));
+
+    it('parses a commit URL with a trailing path', run(Effect.gen(function* () {
+      const target = yield* parseCommitTarget('https://github.com/medic/cht-core/commit/abc1234/files');
+      expect(target).to.deep.equal(COMMIT_TARGET);
+    })));
+
+    [
+      'not-a-commit',
+      'medic/cht-core',
+      'medic/cht-core#',
+      'https://github.com/medic/cht-core/pull/11050',
+    ].forEach(raw => it(`fails on invalid value: ${raw}`, run(Effect.gen(function* () {
+      const either = yield* parseCommitTarget(raw).pipe(Effect.either);
       if (Either.isRight(either)) {
         expect.fail('Expected a parse error');
       }
@@ -160,9 +201,41 @@ describe('Review libs', () => {
     })));
   });
 
+  describe('formatCommitReport', () => {
+    it('renders a commit report with findings', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult(JSON.stringify({
+        comments: [{ path: 'src/a.ts', start_line: 3, end_line: 3, content: 'off-by-one' }],
+      }));
+      const report = formatCommitReport(COMMIT_TARGET, result);
+      expect(report).to.contain('# medic/cht-core@abc1234');
+      expect(report).to.contain('https://github.com/medic/cht-core/commit/abc1234');
+      expect(report).to.contain('Reviewed commit `abc1234`');
+      expect(report).to.contain('### `src/a.ts:3`');
+      expect(report).to.contain('off-by-one');
+    })));
+
+    it('renders the clean message for a commit', run(Effect.gen(function* () {
+      const result = yield* decodeOcrResult(JSON.stringify({ message: 'Looks good.' }));
+      const report = formatCommitReport(COMMIT_TARGET, result);
+      expect(report).to.contain('# medic/cht-core@abc1234');
+      expect(report).to.contain('Looks good.');
+    })));
+  });
+
   describe('reportFileName', () => {
     it('builds a per-PR filename', () => {
       expect(reportFileName(TARGET)).to.equal('medic-cht-core-pr11050.md');
+    });
+  });
+
+  describe('commitReportFileName', () => {
+    it('builds a per-commit filename', () => {
+      expect(commitReportFileName(COMMIT_TARGET)).to.equal('medic-cht-core-commit-abc1234.md');
+    });
+
+    it('replaces path-unsafe characters in the sha', () => {
+      expect(commitReportFileName({ owner: 'medic', repo: 'cht-core', sha: 'feature/x' }))
+        .to.equal('medic-cht-core-commit-feature-x.md');
     });
   });
 });

--- a/test/services/review.spec.ts
+++ b/test/services/review.spec.ts
@@ -1,0 +1,147 @@
+import { describe, it } from 'mocha';
+import { Effect, Either, Layer } from 'effect';
+import sinon, { type SinonStub } from 'sinon';
+import { expect } from 'chai';
+import * as ReviewSvc from '../../src/services/review.ts';
+import { CommandExecutor } from '@effect/platform/CommandExecutor';
+import { FileSystem } from '@effect/platform';
+import { genWithConfig, sandbox } from '../utils/base.ts';
+import esmock from 'esmock';
+
+const GITHUB_TOKEN = 'ghp_test_token';
+const OUTPUT_DIR = '/out';
+const TMP_DIR = '/tmp/review-xyz';
+
+const prData = {
+  title: 'Fix the thing',
+  html_url: 'https://github.com/medic/cht-core/pull/11050',
+  base: { ref: 'master' },
+  head: { ref: 'fix/the-thing' },
+};
+
+const mockCommand = {
+  make: sandbox.stub(),
+  workingDirectory: sandbox.stub(),
+  exitCode: sandbox.stub(),
+  stderr: sandbox.stub(),
+  string: sandbox.stub(),
+};
+const getPullRequest = sandbox.stub();
+const createTmpDir = sandbox.stub();
+const createDir = sandbox.stub();
+const writeFile = sandbox.stub();
+
+const { ReviewService } = await esmock<typeof ReviewSvc>('../../src/services/review.ts', {
+  '@effect/platform': { Command: mockCommand },
+  '../../src/libs/github.ts': { getPullRequest },
+  '../../src/libs/file.ts': { createTmpDir, createDir, writeFile },
+});
+
+const run = genWithConfig(ReviewService.Default.pipe(
+  Layer.provide(Layer.succeed(CommandExecutor, {} as unknown as CommandExecutor)),
+  Layer.provide(Layer.succeed(FileSystem.FileSystem, {} as unknown as FileSystem.FileSystem)),
+))([['GITHUB_TOKEN', GITHUB_TOKEN]]);
+
+const TARGET = { owner: 'medic', repo: 'cht-core', pullNumber: 11050 };
+const OPTIONS = { concurrency: 1, timeout: 60, outputDir: OUTPUT_DIR };
+
+describe('Review Service', () => {
+  let getPr: SinonStub;
+  let writeContent: SinonStub;
+
+  beforeEach(() => {
+    getPr = sinon.stub().returns(Effect.succeed(prData));
+    getPullRequest.returns(getPr);
+    createTmpDir.returns(Effect.succeed(TMP_DIR));
+    createDir.returns(Effect.void);
+    writeContent = sinon.stub().returns(Effect.void);
+    writeFile.returns(writeContent);
+
+    mockCommand.make.returns(Effect.void);
+    mockCommand.workingDirectory.returns(sinon.stub().returns(Effect.void));
+    mockCommand.stderr.returns(sinon.stub().returns(Effect.void));
+    mockCommand.exitCode.returns(Effect.succeed(0));
+    mockCommand.string.returns(Effect.succeed(JSON.stringify({ message: 'No comments generated.' })));
+  });
+
+  it('reviews a PR: checks out the branch, runs ocr, and writes a report', run(function* () {
+    const paths = yield* ReviewService.review([TARGET], OPTIONS);
+
+    expect(paths).to.deep.equal(['/out/medic-cht-core-pr11050.md']);
+
+    expect(getPullRequest).to.have.been.calledOnceWithExactly('medic', 'cht-core');
+    expect(getPr).to.have.been.calledOnceWithExactly(11050);
+
+    // git checkout: init, remote add (with tokenized URL), fetch base + PR head ref
+    expect(mockCommand.make).to.have.been.calledWith('git', 'init', '-q');
+    const remoteUrl = `https://x-access-token:${GITHUB_TOKEN}@github.com/medic/cht-core.git`;
+    expect(mockCommand.make).to.have.been.calledWith('git', 'remote', 'add', 'origin', remoteUrl);
+    expect(mockCommand.make)
+      .to.have.been.calledWith('git', 'fetch', '--no-tags', 'origin', 'master:ocr-base', 'pull/11050/head:ocr-head');
+    expect(mockCommand.workingDirectory).to.have.always.been.calledWith(TMP_DIR);
+
+    // ocr run against the temp checkout
+    const ocrArgs = [
+      'ocr', 'review',
+      '--repo', TMP_DIR,
+      '--from', 'ocr-base',
+      '--to', 'ocr-head',
+      '--format', 'json',
+      '--audience', 'agent',
+      '--concurrency', '1',
+      '--timeout', '60',
+    ];
+    expect(mockCommand.make).to.have.been.calledWith(...ocrArgs);
+
+    // one report written, built from the real formatReport/decode pipeline
+    expect(writeFile).to.have.been.calledOnceWithExactly('/out/medic-cht-core-pr11050.md');
+    const [report] = writeContent.getCall(0).args as [string];
+    expect(report).to.contain('# medic/cht-core#11050: Fix the thing');
+    expect(report).to.contain('No comments generated.');
+  }));
+
+  it('reviews multiple PRs in sequence, one report per PR', run(function* () {
+    const second = { owner: 'medic', repo: 'cht-core', pullNumber: 11051 };
+
+    const paths = yield* ReviewService.review([TARGET, second], OPTIONS);
+
+    expect(paths).to.deep.equal([
+      '/out/medic-cht-core-pr11050.md',
+      '/out/medic-cht-core-pr11051.md',
+    ]);
+    expect(getPr).to.have.been.calledTwice;
+    expect(getPr.getCall(0).args).to.deep.equal([11050]);
+    expect(getPr.getCall(1).args).to.deep.equal([11051]);
+    expect(writeFile).to.have.been.calledTwice;
+    expect(mockCommand.make)
+      .to.have.been.calledWith('git', 'fetch', '--no-tags', 'origin', 'master:ocr-base', 'pull/11051/head:ocr-head');
+  }));
+
+  it('fails when a git command fails', run(function* () {
+    mockCommand.exitCode.returns(Effect.succeed(1));
+
+    const either = yield* ReviewService.review([TARGET], OPTIONS).pipe(Effect.either);
+
+    if (Either.isLeft(either)) {
+      expect(either.left).to.be.instanceOf(Error);
+      expect(either.left.message).to.contain('git init failed');
+      expect(writeFile).to.not.have.been.called;
+    } else {
+      expect.fail('Expected an error to be returned');
+    }
+  }));
+
+  it('propagates errors from the GitHub API', run(function* () {
+    getPr.returns(Effect.fail(new Error('boom')));
+
+    const either = yield* ReviewService.review([TARGET], OPTIONS).pipe(Effect.either);
+
+    if (Either.isLeft(either)) {
+      expect(either.left).to.be.instanceOf(Error);
+      expect(either.left.message).to.equal('boom');
+      expect(writeFile).to.not.have.been.called;
+    } else {
+      expect.fail('Expected an error to be returned');
+    }
+  }));
+});

--- a/test/services/review.spec.ts
+++ b/test/services/review.spec.ts
@@ -65,9 +65,9 @@ describe('Review Service', () => {
   });
 
   it('reviews a PR: checks out the branch, runs ocr, and writes a report', run(function* () {
-    const paths = yield* ReviewService.review([TARGET], OPTIONS);
+    const path = yield* ReviewService.review(TARGET, OPTIONS);
 
-    expect(paths).to.deep.equal(['/out/medic-cht-core-pr11050.md']);
+    expect(path).to.equal('/out/medic-cht-core-pr11050.md');
 
     expect(getPullRequest).to.have.been.calledOnceWithExactly('medic', 'cht-core');
     expect(getPr).to.have.been.calledOnceWithExactly(11050);
@@ -100,19 +100,14 @@ describe('Review Service', () => {
     expect(report).to.contain('No comments generated.');
   }));
 
-  it('reviews multiple PRs in sequence, one report per PR', run(function* () {
-    const second = { owner: 'medic', repo: 'cht-core', pullNumber: 11051 };
+  it('derives the report path and fetch refspec from the given target', run(function* () {
+    const target = { owner: 'medic', repo: 'cht-core', pullNumber: 11051 };
 
-    const paths = yield* ReviewService.review([TARGET, second], OPTIONS);
+    const path = yield* ReviewService.review(target, OPTIONS);
 
-    expect(paths).to.deep.equal([
-      '/out/medic-cht-core-pr11050.md',
-      '/out/medic-cht-core-pr11051.md',
-    ]);
-    expect(getPr).to.have.been.calledTwice;
-    expect(getPr.getCall(0).args).to.deep.equal([11050]);
-    expect(getPr.getCall(1).args).to.deep.equal([11051]);
-    expect(writeFile).to.have.been.calledTwice;
+    expect(path).to.equal('/out/medic-cht-core-pr11051.md');
+    expect(getPr).to.have.been.calledOnceWithExactly(11051);
+    expect(writeFile).to.have.been.calledOnceWithExactly('/out/medic-cht-core-pr11051.md');
     expect(mockCommand.make)
       .to.have.been.calledWith('git', 'fetch', '--no-tags', 'origin', 'master:ocr-base', 'pull/11051/head:ocr-head');
   }));
@@ -120,7 +115,7 @@ describe('Review Service', () => {
   it('fails when a git command fails', run(function* () {
     mockCommand.exitCode.returns(Effect.succeed(1));
 
-    const either = yield* ReviewService.review([TARGET], OPTIONS).pipe(Effect.either);
+    const either = yield* ReviewService.review(TARGET, OPTIONS).pipe(Effect.either);
 
     if (Either.isLeft(either)) {
       expect(either.left).to.be.instanceOf(Error);
@@ -134,7 +129,7 @@ describe('Review Service', () => {
   it('propagates errors from the GitHub API', run(function* () {
     getPr.returns(Effect.fail(new Error('boom')));
 
-    const either = yield* ReviewService.review([TARGET], OPTIONS).pipe(Effect.either);
+    const either = yield* ReviewService.review(TARGET, OPTIONS).pipe(Effect.either);
 
     if (Either.isLeft(either)) {
       expect(either.left).to.be.instanceOf(Error);

--- a/test/services/review.spec.ts
+++ b/test/services/review.spec.ts
@@ -43,6 +43,7 @@ const run = genWithConfig(ReviewService.Default.pipe(
 ))([['GITHUB_TOKEN', GITHUB_TOKEN]]);
 
 const TARGET = { owner: 'medic', repo: 'cht-core', pullNumber: 11050 };
+const COMMIT_TARGET = { owner: 'medic', repo: 'cht-core', sha: 'abc1234' };
 const OPTIONS = { concurrency: 1, timeout: 60, outputDir: OUTPUT_DIR };
 
 describe('Review Service', () => {
@@ -65,7 +66,7 @@ describe('Review Service', () => {
   });
 
   it('reviews a PR: checks out the branch, runs ocr, and writes a report', run(function* () {
-    const path = yield* ReviewService.review(TARGET, OPTIONS);
+    const path = yield* ReviewService.reviewPr(TARGET, OPTIONS);
 
     expect(path).to.equal('/out/medic-cht-core-pr11050.md');
 
@@ -103,7 +104,7 @@ describe('Review Service', () => {
   it('derives the report path and fetch refspec from the given target', run(function* () {
     const target = { owner: 'medic', repo: 'cht-core', pullNumber: 11051 };
 
-    const path = yield* ReviewService.review(target, OPTIONS);
+    const path = yield* ReviewService.reviewPr(target, OPTIONS);
 
     expect(path).to.equal('/out/medic-cht-core-pr11051.md');
     expect(getPr).to.have.been.calledOnceWithExactly(11051);
@@ -115,7 +116,7 @@ describe('Review Service', () => {
   it('fails when a git command fails', run(function* () {
     mockCommand.exitCode.returns(Effect.succeed(1));
 
-    const either = yield* ReviewService.review(TARGET, OPTIONS).pipe(Effect.either);
+    const either = yield* ReviewService.reviewPr(TARGET, OPTIONS).pipe(Effect.either);
 
     if (Either.isLeft(either)) {
       expect(either.left).to.be.instanceOf(Error);
@@ -129,7 +130,7 @@ describe('Review Service', () => {
   it('propagates errors from the GitHub API', run(function* () {
     getPr.returns(Effect.fail(new Error('boom')));
 
-    const either = yield* ReviewService.review(TARGET, OPTIONS).pipe(Effect.either);
+    const either = yield* ReviewService.reviewPr(TARGET, OPTIONS).pipe(Effect.either);
 
     if (Either.isLeft(either)) {
       expect(either.left).to.be.instanceOf(Error);
@@ -139,4 +140,53 @@ describe('Review Service', () => {
       expect.fail('Expected an error to be returned');
     }
   }));
+
+  describe('reviewCommit', () => {
+    it('clones the commit repo, runs ocr against it, and writes a report', run(function* () {
+      const path = yield* ReviewService.reviewCommit(COMMIT_TARGET, OPTIONS);
+
+      expect(path).to.equal('/out/medic-cht-core-commit-abc1234.md');
+
+      // commit reviews clone into a temp dir but do not hit the PR API
+      expect(getPullRequest).to.not.have.been.called;
+      expect(createTmpDir).to.have.been.calledOnce;
+
+      // git checkout: init, remote add (with tokenized URL), fetch the commit sha
+      expect(mockCommand.make).to.have.been.calledWith('git', 'init', '-q');
+      const remoteUrl = `https://x-access-token:${GITHUB_TOKEN}@github.com/medic/cht-core.git`;
+      expect(mockCommand.make).to.have.been.calledWith('git', 'remote', 'add', 'origin', remoteUrl);
+      expect(mockCommand.make).to.have.been.calledWith('git', 'fetch', '--no-tags', 'origin', 'abc1234');
+      expect(mockCommand.workingDirectory).to.have.always.been.calledWith(TMP_DIR);
+
+      // ocr reviews the commit against its parent in the temp checkout
+      const ocrArgs = [
+        'ocr', 'review',
+        '--repo', TMP_DIR,
+        '--commit', 'abc1234',
+        '--format', 'json',
+        '--audience', 'agent',
+        '--concurrency', '1',
+        '--timeout', '60',
+      ];
+      expect(mockCommand.make).to.have.been.calledWith(...ocrArgs);
+
+      expect(writeFile).to.have.been.calledOnceWithExactly('/out/medic-cht-core-commit-abc1234.md');
+      const [report] = writeContent.getCall(0).args as [string];
+      expect(report).to.contain('# medic/cht-core@abc1234');
+      expect(report).to.contain('No comments generated.');
+    }));
+
+    it('propagates ocr errors', run(function* () {
+      mockCommand.string.returns(Effect.fail(new Error('ocr exploded')));
+
+      const either = yield* ReviewService.reviewCommit(COMMIT_TARGET, OPTIONS).pipe(Effect.either);
+
+      if (Either.isLeft(either)) {
+        expect(either.left).to.be.instanceOf(Error);
+        expect(writeFile).to.not.have.been.called;
+      } else {
+        expect.fail('Expected an error to be returned');
+      }
+    }));
+  });
 });

--- a/test/services/review.spec.ts
+++ b/test/services/review.spec.ts
@@ -94,9 +94,14 @@ describe('Review Service', () => {
     ];
     expect(mockCommand.make).to.have.been.calledWith(...ocrArgs);
 
-    // one report written, built from the real formatReport/decode pipeline
-    expect(writeFile).to.have.been.calledOnceWithExactly('/out/medic-cht-core-pr11050.md');
-    const [report] = writeContent.getCall(0).args as [string];
+    // the ocr rule file is written into the cloned repo
+    expect(writeFile).to.have.been.calledWith(`${TMP_DIR}/.opencodereview/rule.json`);
+    const [ruleContent] = writeContent.getCall(0).args as [string];
+    expect(JSON.parse(ruleContent)).to.deep.equal({ rules: [], include: ['**/*.spec.{js,jsx,ts,tsx}'] });
+
+    // the report is written, built from the real formatReport/decode pipeline
+    expect(writeFile).to.have.been.calledWith('/out/medic-cht-core-pr11050.md');
+    const [report] = writeContent.lastCall.args as [string];
     expect(report).to.contain('# medic/cht-core#11050: Fix the thing');
     expect(report).to.contain('No comments generated.');
   }));
@@ -108,7 +113,7 @@ describe('Review Service', () => {
 
     expect(path).to.equal('/out/medic-cht-core-pr11051.md');
     expect(getPr).to.have.been.calledOnceWithExactly(11051);
-    expect(writeFile).to.have.been.calledOnceWithExactly('/out/medic-cht-core-pr11051.md');
+    expect(writeFile).to.have.been.calledWith('/out/medic-cht-core-pr11051.md');
     expect(mockCommand.make)
       .to.have.been.calledWith('git', 'fetch', '--no-tags', 'origin', 'master:ocr-base', 'pull/11051/head:ocr-head');
   }));
@@ -170,20 +175,25 @@ describe('Review Service', () => {
       ];
       expect(mockCommand.make).to.have.been.calledWith(...ocrArgs);
 
-      expect(writeFile).to.have.been.calledOnceWithExactly('/out/medic-cht-core-commit-abc1234.md');
-      const [report] = writeContent.getCall(0).args as [string];
+      // the ocr rule file is written into the cloned repo
+      expect(writeFile).to.have.been.calledWith(`${TMP_DIR}/.opencodereview/rule.json`);
+      const [ruleContent] = writeContent.getCall(0).args as [string];
+      expect(JSON.parse(ruleContent)).to.deep.equal({ rules: [], include: ['**/*.spec.{js,jsx,ts,tsx}'] });
+
+      expect(writeFile).to.have.been.calledWith('/out/medic-cht-core-commit-abc1234.md');
+      const [report] = writeContent.lastCall.args as [string];
       expect(report).to.contain('# medic/cht-core@abc1234');
       expect(report).to.contain('No comments generated.');
     }));
 
-    it('propagates ocr errors', run(function* () {
+    it('propagates ocr errors without writing a report', run(function* () {
       mockCommand.string.returns(Effect.fail(new Error('ocr exploded')));
 
       const either = yield* ReviewService.reviewCommit(COMMIT_TARGET, OPTIONS).pipe(Effect.either);
 
       if (Either.isLeft(either)) {
         expect(either.left).to.be.instanceOf(Error);
-        expect(writeFile).to.not.have.been.called;
+        expect(writeFile).to.not.have.been.calledWith('/out/medic-cht-core-commit-abc1234.md');
       } else {
         expect.fail('Expected an error to be returned');
       }


### PR DESCRIPTION
Adds new `review` command that wraps interactions with a local deployment of https://github.com/alibaba/open-code-review (installed separately).  

The `review` command currently has two main advantages over just calling open-code-review direction:

1. You can queue up multiple PRs/commits to review. The reviews will all be done sequentially, providing the opportunity for long-running batch jobs.
2. For each review, a temporary repo is automatically checked out and cleaned up. So, you do not have try manage any code/branches locally.